### PR TITLE
fix(current): show installation status and hide unconfigured runtimes

### DIFF
--- a/src/cmd/current.go
+++ b/src/cmd/current.go
@@ -8,6 +8,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// runtimeStatus holds the status of a configured runtime
+type runtimeStatus struct {
+	provider  runtime.Provider
+	version   string
+	installed bool
+}
+
 var currentCmd = &cobra.Command{
 	Use:   "current [runtime]",
 	Short: "Show the currently active version(s)",
@@ -21,43 +28,102 @@ Examples:
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			// Show all active versions
-			ui.Header("Currently active versions:")
-			providers := runtime.GetAll()
-
-			if len(providers) == 0 {
-				ui.Info("No runtime providers registered")
-				return
-			}
-
-			for _, provider := range providers {
-				version, err := provider.CurrentVersion()
-				if err != nil {
-					fmt.Printf("  %s: %v\n", provider.DisplayName(), err)
-				} else {
-					fmt.Printf("  %s: %s\n", ui.Highlight(provider.DisplayName()), ui.HighlightVersion(version))
-				}
-			}
+			showAllVersions()
 		} else {
-			// Show specific runtime version
-			runtimeName := args[0]
-
-			provider, err := runtime.Get(runtimeName)
-			if err != nil {
-				ui.Error("%v", err)
-				ui.Info("Available runtimes: %v", runtime.List())
-				return
-			}
-
-			version, err := provider.CurrentVersion()
-			if err != nil {
-				ui.Error("%v", err)
-				return
-			}
-
-			fmt.Printf("%s: %s\n", ui.Highlight(provider.DisplayName()), ui.HighlightVersion(version))
+			showSingleVersion(args[0])
 		}
 	},
+}
+
+// showAllVersions displays all configured runtimes and prompts to install missing ones
+func showAllVersions() {
+	providers := runtime.GetAll()
+
+	if len(providers) == 0 {
+		ui.Info("No runtime providers registered")
+		return
+	}
+
+	// Collect status for all configured runtimes
+	var configured []runtimeStatus
+	for _, provider := range providers {
+		version, err := provider.CurrentVersion()
+		if err != nil {
+			// Not configured - skip it
+			continue
+		}
+		installed, _ := provider.IsInstalled(version)
+		configured = append(configured, runtimeStatus{
+			provider:  provider,
+			version:   version,
+			installed: installed,
+		})
+	}
+
+	if len(configured) == 0 {
+		ui.Info("No runtimes configured")
+		return
+	}
+
+	// Display all configured versions
+	ui.Header("Currently active versions:")
+	var missing []runtimeStatus
+	for _, rs := range configured {
+		if rs.installed {
+			fmt.Printf("  %s: %s\n", ui.Highlight(rs.provider.DisplayName()), ui.HighlightVersion(rs.version))
+		} else {
+			ui.Warning("%s: %s (not installed)", rs.provider.DisplayName(), rs.version)
+			missing = append(missing, rs)
+		}
+	}
+
+	// Prompt to install missing versions
+	if len(missing) > 0 {
+		fmt.Println()
+		if ui.PromptInstallMissing(missing) {
+			for _, rs := range missing {
+				ui.Info("Installing %s %s...", rs.provider.DisplayName(), rs.version)
+				if err := rs.provider.Install(rs.version); err != nil {
+					ui.Error("Failed to install %s %s: %v", rs.provider.DisplayName(), rs.version, err)
+				} else {
+					ui.Success("%s %s installed successfully", rs.provider.DisplayName(), rs.version)
+				}
+			}
+		}
+	}
+}
+
+// showSingleVersion displays a single runtime version and prompts to install if missing
+func showSingleVersion(runtimeName string) {
+	provider, err := runtime.Get(runtimeName)
+	if err != nil {
+		ui.Error("%v", err)
+		ui.Info("Available runtimes: %v", runtime.List())
+		return
+	}
+
+	version, err := provider.CurrentVersion()
+	if err != nil {
+		ui.Error("%v", err)
+		return
+	}
+
+	installed, _ := provider.IsInstalled(version)
+	if installed {
+		fmt.Printf("%s: %s\n", ui.Highlight(provider.DisplayName()), ui.HighlightVersion(version))
+		return
+	}
+
+	// Not installed - show with warning and prompt
+	ui.Warning("%s: %s (not installed)", provider.DisplayName(), version)
+	fmt.Println()
+	if ui.PromptInstall(provider.DisplayName(), version) {
+		if err := provider.Install(version); err != nil {
+			ui.Error("Failed to install %s %s: %v", provider.DisplayName(), version, err)
+			return
+		}
+		ui.Success("%s %s installed successfully", provider.DisplayName(), version)
+	}
 }
 
 func init() {

--- a/src/cmd/shim/main.go
+++ b/src/cmd/shim/main.go
@@ -194,33 +194,10 @@ func findInSystemPath(execName string) string {
 	return ""
 }
 
-// shouldAutoInstall prompts the user to install a missing version
-// Returns true if the user wants to install, false otherwise
+// shouldAutoInstall prompts the user to install a missing version.
+// Delegates to ui.PromptInstall for consistent behavior across CLI and shim.
 func shouldAutoInstall(displayName, version string) bool {
-	// Check if running in non-interactive mode (CI/automation)
-	if os.Getenv("DTVEM_AUTO_INSTALL") == "false" {
-		return false
-	}
-
-	// If DTVEM_AUTO_INSTALL=true, auto-install without prompting
-	if os.Getenv("DTVEM_AUTO_INSTALL") == "true" {
-		return true
-	}
-
-	// Interactive prompt
-	ui.Warning("%s %s is not installed", displayName, version)
-	ui.Info("Install it now? [Y/n]: ")
-
-	var response string
-	_, _ = fmt.Scanln(&response)
-	response = strings.ToLower(strings.TrimSpace(response))
-
-	// Default to "yes" if empty response
-	if response == "" || response == constants.ResponseY || response == constants.ResponseYes {
-		return true
-	}
-
-	return false
+	return ui.PromptInstall(displayName, version)
 }
 
 // getShimName returns the name of this shim binary


### PR DESCRIPTION
## Summary
- Show warning icon and "(not installed)" for configured but missing versions
- Prompt to install missing versions (respects `DTVEM_AUTO_INSTALL`)
- Hide unconfigured runtimes from output
- Extract `PromptInstall` to ui package for reuse
- Refactor shim to use shared `PromptInstall` function

## Test plan
- [ ] Run `dtvem current` with a configured but uninstalled version
- [ ] Verify warning icon appears next to uninstalled versions
- [ ] Verify prompt to install appears
- [ ] Verify unconfigured runtimes are not shown
- [ ] Test with `DTVEM_AUTO_INSTALL=true` and `DTVEM_AUTO_INSTALL=false`

Fixes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)