### PR TITLE
fix(shim): propagate exit code instead of reporting failure on windows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# Claude Code Instructions for dtvem
+
+## Deployment
+
+After building, always deploy both executables to the user's installation directory:
+
+```bash
+cp dist/dtvem.exe ~/.dtvem/bin/dtvem.exe
+cp dist/shim.exe ~/.dtvem/bin/dtvem-shim.exe
+~/.dtvem/bin/dtvem.exe reshim
+```
+
+The `reshim` command must be run after deploying the shim to regenerate all runtime shims (npm, node, python, etc.) with the updated binary.


### PR DESCRIPTION
## Summary
- Fix Windows shim incorrectly reporting "failed to execute" when commands exit with non-zero code
- Detect `*exec.ExitError` and propagate the actual exit code via `os.Exit()` instead of treating it as a failure
- Add CLAUDE.md with deployment instructions

Fixes #59

## Test plan
- [ ] Run `npm --version` via dtvem shim on Windows - should show version without error
- [ ] Run a command that exits with non-zero code - should propagate exit code silently
- [ ] Verify actual failures (e.g., missing executable) still report errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)