### PR TITLE
chore(release): categorize changelog by commit type

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,10 +257,56 @@ jobs:
         PREVIOUS_TAG=$(git describe --abbrev=0 --tags --match "v*" 2>/dev/null || echo "")
         if [ -z "$PREVIOUS_TAG" ]; then
           # First release - get all commits
-          CHANGELOG=$(git log --pretty=format:"- %s (%h)" --no-merges)
+          COMMITS=$(git log --pretty=format:"%s (%h)|%b" --no-merges | tr '\n' ' ')
         else
           # Get commits since previous tag
-          CHANGELOG=$(git log ${PREVIOUS_TAG}..HEAD --pretty=format:"- %s (%h)" --no-merges)
+          COMMITS=$(git log ${PREVIOUS_TAG}..HEAD --pretty=format:"%s (%h)|%b" --no-merges | tr '\n' ' ')
+        fi
+
+        # Categorize commits by conventional commit type
+        BUGS=""
+        FEATURES=""
+        CHORES=""
+
+        # Process each commit
+        while IFS= read -r line; do
+          subject=$(echo "$line" | cut -d'|' -f1)
+          body=$(echo "$line" | cut -d'|' -f2-)
+
+          # Extract issue number from body if present
+          issue=$(echo "$body" | grep -oE "Fixes #[0-9]+" | head -1 || echo "")
+          if [ -n "$issue" ]; then
+            entry="- $subject - $issue"
+          else
+            entry="- $subject"
+          fi
+
+          # Categorize by prefix
+          if echo "$subject" | grep -qE "^fix(\(|:)"; then
+            BUGS="${BUGS}${entry}"$'\n'
+          elif echo "$subject" | grep -qE "^feat(\(|:)"; then
+            FEATURES="${FEATURES}${entry}"$'\n'
+          elif echo "$subject" | grep -qE "^chore(\(|:)"; then
+            CHORES="${CHORES}${entry}"$'\n'
+          else
+            # Default to chores for uncategorized
+            CHORES="${CHORES}${entry}"$'\n'
+          fi
+        done < <(git log ${PREVIOUS_TAG:+$PREVIOUS_TAG..}HEAD --pretty=format:"%s (%h)|%b---END---" --no-merges | sed 's/---END---/\n/g')
+
+        # Build changelog with categories
+        CHANGELOG=""
+
+        if [ -n "$BUGS" ]; then
+          CHANGELOG="${CHANGELOG}### 🐛 Bugs Squashed"$'\n\n'"${BUGS}"$'\n'
+        fi
+
+        if [ -n "$FEATURES" ]; then
+          CHANGELOG="${CHANGELOG}### 🎉 Features Added"$'\n\n'"${FEATURES}"$'\n'
+        fi
+
+        if [ -n "$CHORES" ]; then
+          CHANGELOG="${CHANGELOG}### 🧹 Chores Addressed"$'\n\n'"${CHORES}"$'\n'
         fi
 
         # If changelog is empty, use a fun message

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # Claude Code Instructions for dtvem
 
+## Commits
+
+All commits must be authored by `calvin@codingwithcalvin.net`. Do not add co-authors (including Claude) to commits.
+
 ## Deployment
 
 After building, always deploy both executables to the user's installation directory:


### PR DESCRIPTION
## Summary

Generate release changelog with categorized sections based on conventional commit types:

- 🐛 Bugs Squashed (fix commits)
- 🎉 Features Added (feat commits)  
- 🧹 Chores Addressed (chore and other commits)

Also extracts issue numbers from commit bodies when present (e.g., "Fixes #59").

## Example Output

```markdown
### 🐛 Bugs Squashed

- fix(shim): propagate exit code instead of reporting failure on windows (831a6c3) - Fixes #59
- fix(init): use system path on windows for correct priority (925d7bb) - Fixes #55

### 🎉 Features Added

- feat(list): show all runtimes and indicate global version (bae8e28) - Fixes #54

### 🧹 Chores Addressed

- chore: Add conventional commit configuration (1d8a2ad)
```

## Test plan

- [ ] Run release workflow and verify changelog is categorized correctly