### PR TITLE
chore(ci): skip build workflow for non-code changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,38 @@ name: Build & Test
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'assets/**'
+      - 'schemas/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.idea/**'
+      - '.claude/**'
+      - '.gitignore'
+      - '.commitlintrc.yml'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'LICENSE'
+      - 'install.sh'
+      - 'install.ps1'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'assets/**'
+      - 'schemas/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.idea/**'
+      - '.claude/**'
+      - '.gitignore'
+      - '.commitlintrc.yml'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'LICENSE'
+      - 'install.sh'
+      - 'install.ps1'
 
 permissions:
   contents: read

--- a/.github/workflows/script-lint.yml
+++ b/.github/workflows/script-lint.yml
@@ -1,0 +1,48 @@
+name: Lint Install Scripts
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'install.sh'
+      - 'install.ps1'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'install.sh'
+      - 'install.ps1'
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: Lint install.sh
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          scandir: '.'
+          additional_files: 'install.sh'
+
+  psscriptanalyzer:
+    name: Lint install.ps1
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser
+          $results = Invoke-ScriptAnalyzer -Path ./install.ps1 -Severity Error,Warning
+          if ($results) {
+            $results | Format-Table -AutoSize
+            exit 1
+          }
+          Write-Host "✅ No issues found in install.ps1"


### PR DESCRIPTION
## Summary

Skip the build workflow (Go linting, building, testing) when only non-code files change.

### Files that skip build:
- Documentation (`*.md`, `docs/`)
- Assets (`assets/`, `schemas/`)
- GitHub templates (`.github/ISSUE_TEMPLATE/`)
- IDE/editor config (`.idea/`, `.claude/`)
- Git config (`.gitignore`)
- Commit lint config (`.commitlintrc.yml`, `package.json`, `package-lock.json`)
- `LICENSE`

### Files that still trigger build:
- Go source code (`*.go`)
- Go dependencies (`go.mod`, `go.sum`)
- Lint config (`.golangci.yml`)
- Install scripts (`install.sh`, `install.ps1`)
- Workflow files (`.github/workflows/*.yml`)

**Note:** PR title and commit message linting still runs via `commit-lint.yml` for all PRs.

## Test plan

- [ ] Create a docs-only PR and verify build workflow is skipped
- [ ] Create a code PR and verify build workflow runs