### PR TITLE
perf(ci): strip debug symbols from builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
 
     - name: Build main CLI
       run: |
-        go build -v -o dist/dtvem${{ matrix.goos == 'windows' && '.exe' || '' }} ./src
+        go build -v -ldflags="-s -w" -o dist/dtvem${{ matrix.goos == 'windows' && '.exe' || '' }} ./src
       shell: bash
       env:
         GOOS: ${{ matrix.goos }}
@@ -148,7 +148,7 @@ jobs:
 
     - name: Build shim executable
       run: |
-        go build -v -o dist/dtvem-shim${{ matrix.goos == 'windows' && '.exe' || '' }} ./src/cmd/shim
+        go build -v -ldflags="-s -w" -o dist/dtvem-shim${{ matrix.goos == 'windows' && '.exe' || '' }} ./src/cmd/shim
       shell: bash
       env:
         GOOS: ${{ matrix.goos }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,7 +179,7 @@ jobs:
 
     - name: Build main CLI
       run: |
-        go build -v -o dist/dtvem${{ matrix.goos == 'windows' && '.exe' || '' }} ./src
+        go build -v -ldflags="-s -w" -o dist/dtvem${{ matrix.goos == 'windows' && '.exe' || '' }} ./src
       shell: bash
       env:
         GOOS: ${{ matrix.goos }}
@@ -187,7 +187,7 @@ jobs:
 
     - name: Build shim executable
       run: |
-        go build -v -o dist/dtvem-shim${{ matrix.goos == 'windows' && '.exe' || '' }} ./src/cmd/shim
+        go build -v -ldflags="-s -w" -o dist/dtvem-shim${{ matrix.goos == 'windows' && '.exe' || '' }} ./src/cmd/shim
       shell: bash
       env:
         GOOS: ${{ matrix.goos }}


### PR DESCRIPTION
## Summary

- Add `-ldflags="-s -w"` to go build commands in both build and release workflows
- Removes symbol table and DWARF debug information from binaries

## Impact

Reduces binary sizes by ~30%:

| Binary | Before | After | Savings |
|--------|--------|-------|---------|
| dtvem | ~10.9MB | ~7.5MB | ~3.4MB |
| dtvem-shim | ~10.3MB | ~7.2MB | ~3.1MB |

Total savings per release: ~32MB across all 5 platform builds.

## Test plan

- [ ] CI build workflow passes
- [ ] Verify binaries still function correctly after stripping

Fixes #72