### PR TITLE
fix(ci): restore conventional commit categorization

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -30,29 +30,43 @@ jobs:
 
         echo "Previous tag: ${PREVIOUS_TAG:-'(none - first release)'}"
 
-        # Get commit SHAs since last release
+        # Get commit data since last release
         if [ -z "$PREVIOUS_TAG" ]; then
-          COMMIT_SHAS=$(git log --pretty=format:"%H" --no-merges)
+          COMMIT_RANGE="HEAD"
         else
-          COMMIT_SHAS=$(git log ${PREVIOUS_TAG}..HEAD --pretty=format:"%H" --no-merges)
+          COMMIT_RANGE="${PREVIOUS_TAG}..HEAD"
         fi
 
-        echo "Found $(echo "$COMMIT_SHAS" | wc -l) commits since last release"
+        # Collect highlights from PR comments and categorize commits
+        # Each category stores entries with issue number prefix for sorting: "NNNN|entry"
+        declare -a HIGHLIGHTS
+        declare -a BUGS           # fix
+        declare -a IMPROVEMENTS   # perf, refactor
+        declare -a FEATURES       # feat
+        declare -a MAINTENANCE    # docs, style, test, build, ci, chore
+        declare -a OTHER          # anything else (except revert which is omitted)
 
-        # Collect all closed issues by tracing commits -> PRs -> issues
-        declare -A CLOSED_ISSUES  # issue_number -> issue_title
-        declare -a HIGHLIGHTS     # array of highlight messages
+        # Process each commit
+        while IFS= read -r line; do
+          [ -z "$line" ] && continue
 
-        for SHA in $COMMIT_SHAS; do
+          SHA=$(echo "$line" | cut -d'|' -f1)
+          SUBJECT=$(echo "$line" | cut -d'|' -f2)
+          SHORT_SHA=$(echo "$line" | cut -d'|' -f3)
+          BODY=$(echo "$line" | cut -d'|' -f4-)
+
           echo "Processing commit: $SHA"
 
-          # Find PR associated with this commit (squash merge)
-          PR_DATA=$(gh pr list --search "$SHA" --state merged --json number,body --limit 1 2>/dev/null || echo "[]")
+          # Skip revert commits
+          if echo "$SUBJECT" | grep -qE "^revert(\(|:)"; then
+            echo "  Skipping revert commit"
+            continue
+          fi
 
+          # Check for PR and /release-note comments
+          PR_DATA=$(gh pr list --search "$SHA" --state merged --json number --limit 1 2>/dev/null || echo "[]")
           if [ "$PR_DATA" != "[]" ] && [ -n "$PR_DATA" ]; then
             PR_NUMBER=$(echo "$PR_DATA" | jq -r '.[0].number // empty')
-            PR_BODY=$(echo "$PR_DATA" | jq -r '.[0].body // ""')
-
             if [ -n "$PR_NUMBER" ]; then
               echo "  Found PR #$PR_NUMBER"
 
@@ -63,44 +77,44 @@ jobs:
                 echo "  Found /release-note: $RELEASE_NOTE"
                 HIGHLIGHTS+=("$RELEASE_NOTE")
               fi
-
-              # Extract issue numbers from PR body (Fixes #XX, Closes #XX, Resolves #XX)
-              ISSUE_NUMBERS=$(echo "$PR_BODY" | grep -oiE "(fixes|closes|resolves)\s*#[0-9]+" | grep -oE "[0-9]+" || echo "")
-
-              for ISSUE_NUM in $ISSUE_NUMBERS; do
-                if [ -z "${CLOSED_ISSUES[$ISSUE_NUM]}" ]; then
-                  echo "  Found linked issue #$ISSUE_NUM"
-
-                  # Get issue title
-                  ISSUE_TITLE=$(gh issue view "$ISSUE_NUM" --json title --jq '.title' 2>/dev/null || echo "")
-
-                  if [ -n "$ISSUE_TITLE" ]; then
-                    CLOSED_ISSUES[$ISSUE_NUM]="$ISSUE_TITLE"
-                  fi
-                fi
-              done
             fi
           fi
-        done
 
-        # Also check for issues closed directly (not via PR) in the commit range
-        # by looking at commit messages for "Fixes #XX" patterns
-        for SHA in $COMMIT_SHAS; do
-          COMMIT_MSG=$(git log -1 --pretty=format:"%B" "$SHA")
-          ISSUE_NUMBERS=$(echo "$COMMIT_MSG" | grep -oiE "(fixes|closes|resolves)\s*#[0-9]+" | grep -oE "[0-9]+" || echo "")
+          # Extract issue number from commit body for sorting
+          ISSUE_NUM=$(echo "$BODY" | grep -oiE "(fixes|closes|resolves)\s*#[0-9]+" | grep -oE "[0-9]+" | head -1 || echo "99999")
+          ISSUE_REF=$(echo "$BODY" | grep -oiE "(fixes|closes|resolves)\s*#[0-9]+" | head -1 || echo "")
 
-          for ISSUE_NUM in $ISSUE_NUMBERS; do
-            if [ -z "${CLOSED_ISSUES[$ISSUE_NUM]}" ]; then
-              echo "Found issue #$ISSUE_NUM in commit message"
+          # Build commit entry
+          if [ -n "$ISSUE_NUM" ] && [ "$ISSUE_NUM" != "99999" ]; then
+            ENTRY="- #${ISSUE_NUM} - $SUBJECT ($SHORT_SHA)"
+          else
+            ENTRY="- $SUBJECT ($SHORT_SHA)"
+          fi
 
-              ISSUE_TITLE=$(gh issue view "$ISSUE_NUM" --json title --jq '.title' 2>/dev/null || echo "")
+          # Store with issue number prefix for sorting
+          SORTABLE_ENTRY="${ISSUE_NUM}|${ENTRY}"
 
-              if [ -n "$ISSUE_TITLE" ]; then
-                CLOSED_ISSUES[$ISSUE_NUM]="$ISSUE_TITLE"
-              fi
-            fi
-          done
-        done
+          # Categorize by conventional commit prefix
+          if echo "$SUBJECT" | grep -qE "^fix(\(|:)"; then
+            BUGS+=("$SORTABLE_ENTRY")
+          elif echo "$SUBJECT" | grep -qE "^(perf|refactor)(\(|:)"; then
+            IMPROVEMENTS+=("$SORTABLE_ENTRY")
+          elif echo "$SUBJECT" | grep -qE "^feat(\(|:)"; then
+            FEATURES+=("$SORTABLE_ENTRY")
+          elif echo "$SUBJECT" | grep -qE "^(docs|style|test|build|ci|chore)(\(|:)"; then
+            MAINTENANCE+=("$SORTABLE_ENTRY")
+          else
+            OTHER+=("$SORTABLE_ENTRY")
+          fi
+        done < <(git log ${COMMIT_RANGE} --pretty=format:"%H|%s|%h|%b---END---" --no-merges | sed 's/---END---/\n/g')
+
+        # Helper function to sort entries by issue number and format output
+        sort_entries() {
+          local -n arr=$1
+          if [ ${#arr[@]} -gt 0 ]; then
+            printf '%s\n' "${arr[@]}" | sort -t'|' -k1 -n | cut -d'|' -f2-
+          fi
+        }
 
         # Build changelog
         CHANGELOG=""
@@ -114,13 +128,45 @@ jobs:
           CHANGELOG="${CHANGELOG}"$'\n'
         fi
 
-        # Add Closed Issues section (always show if there are any)
-        if [ ${#CLOSED_ISSUES[@]} -gt 0 ]; then
-          CHANGELOG="${CHANGELOG}### 📋 Closed Issues"$'\n\n'
-          # Sort issue numbers for consistent ordering
-          for ISSUE_NUM in $(echo "${!CLOSED_ISSUES[@]}" | tr ' ' '\n' | sort -n); do
-            CHANGELOG="${CHANGELOG}- #${ISSUE_NUM} - ${CLOSED_ISSUES[$ISSUE_NUM]}"$'\n'
-          done
+        # Add categorized sections in order: Bug Fixes, Performance & Improvements, New Features, Maintenance, Other
+        if [ ${#BUGS[@]} -gt 0 ]; then
+          CHANGELOG="${CHANGELOG}### 🐛 Bug Fixes"$'\n\n'
+          while IFS= read -r entry; do
+            CHANGELOG="${CHANGELOG}${entry}"$'\n'
+          done < <(sort_entries BUGS)
+          CHANGELOG="${CHANGELOG}"$'\n'
+        fi
+
+        if [ ${#IMPROVEMENTS[@]} -gt 0 ]; then
+          CHANGELOG="${CHANGELOG}### ⚡ Performance & Improvements"$'\n\n'
+          while IFS= read -r entry; do
+            CHANGELOG="${CHANGELOG}${entry}"$'\n'
+          done < <(sort_entries IMPROVEMENTS)
+          CHANGELOG="${CHANGELOG}"$'\n'
+        fi
+
+        if [ ${#FEATURES[@]} -gt 0 ]; then
+          CHANGELOG="${CHANGELOG}### 🎉 New Features"$'\n\n'
+          while IFS= read -r entry; do
+            CHANGELOG="${CHANGELOG}${entry}"$'\n'
+          done < <(sort_entries FEATURES)
+          CHANGELOG="${CHANGELOG}"$'\n'
+        fi
+
+        if [ ${#MAINTENANCE[@]} -gt 0 ]; then
+          CHANGELOG="${CHANGELOG}### 🔧 Maintenance"$'\n\n'
+          while IFS= read -r entry; do
+            CHANGELOG="${CHANGELOG}${entry}"$'\n'
+          done < <(sort_entries MAINTENANCE)
+          CHANGELOG="${CHANGELOG}"$'\n'
+        fi
+
+        if [ ${#OTHER[@]} -gt 0 ]; then
+          CHANGELOG="${CHANGELOG}### 📦 Other"$'\n\n'
+          while IFS= read -r entry; do
+            CHANGELOG="${CHANGELOG}${entry}"$'\n'
+          done < <(sort_entries OTHER)
+          CHANGELOG="${CHANGELOG}"$'\n'
         fi
 
         # If changelog is empty, use a fun message


### PR DESCRIPTION
## Summary

Restore categorized sections based on conventional commit prefixes:

- 🐛 Bug Fixes (`fix`)
- ⚡ Performance & Improvements (`perf`, `refactor`)
- 🎉 New Features (`feat`)
- 🔧 Maintenance (`docs`, `style`, `test`, `build`, `ci`, `chore`)
- 📦 Other (uncategorized)

Additional changes:
- Entries within each section are sorted by issue number (ascending)
- Issue number shown at the front of each entry
- Revert commits are omitted from the changelog
- Keeps the `/release-note` highlight feature from PR comments

## Example Output

```markdown
### ✨ Highlights

- Shim binary is now 56% smaller with faster startup

### 🐛 Bug Fixes

- #55 - fix(init): use system path on windows for correct priority (925d7bb)
- #59 - fix(shim): propagate exit code instead of reporting failure on windows (831a6c3)

### ⚡ Performance & Improvements

- #72 - perf(shim): optimize shim startup time and binary size (abc1234)
- #74 - refactor(shim): implement lite provider interface (7eddaac)

### 🎉 New Features

- #54 - feat(list): show all runtimes and indicate global version (bae8e28)

### 🔧 Maintenance

- chore(ci): skip build for changelog workflow changes (a650738)
- docs: update documentation for today's changes (da237dd)
```

## Test plan

- [ ] Run "Preview Changelog" workflow to verify categorization works
- [ ] Verify entries are sorted by issue number within each category
- [ ] Verify issue number appears at the front of each entry