### PR TITLE
feat(dx): add npm scripts for common development tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,17 @@
   "private": true,
   "description": "Development dependencies for dtvem - requires Node.js via dtvem",
   "scripts": {
-    "prepare": "husky"
+    "prepare": "husky",
+    "format": "gofmt -w ./src",
+    "lint": "golangci-lint run --timeout=5m --config=.golangci.yml ./src/...",
+    "test": "go test -v ./src/...",
+    "test:coverage": "go test -v -coverprofile=coverage.out -covermode=atomic ./src/... && go tool cover -html=coverage.out -o coverage.html",
+    "build": "npm run build:cli && npm run build:shim",
+    "build:cli": "go build -v -ldflags=\"-s -w\" -o dist/dtvem.exe ./src",
+    "build:shim": "go build -v -ldflags=\"-s -w\" -o dist/dtvem-shim.exe ./src/cmd/shim",
+    "install": "npm run build && cp dist/dtvem.exe ~/.dtvem/bin/dtvem.exe && cp dist/dtvem-shim.exe ~/.dtvem/bin/dtvem-shim.exe && ~/.dtvem/bin/dtvem.exe reshim",
+    "clean": "rm -rf dist coverage.out coverage.html",
+    "check": "npm run format && npm run lint && npm run test"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.0.0",


### PR DESCRIPTION
## Summary

Add npm scripts for common development tasks, using Node.js/npm as our task runner.

## Available Scripts

| Script | Description |
|--------|-------------|
| `npm run format` | Format all Go source files |
| `npm run lint` | Run golangci-lint |
| `npm run test` | Run all tests |
| `npm run test:coverage` | Run tests with coverage report |
| `npm run build` | Build both CLI and shim binaries |
| `npm run install` | Build and install to ~/.dtvem/bin |
| `npm run clean` | Clean build artifacts |
| `npm run check` | Run format, lint, and test |

## Why npm?

- Already required for commitlint/husky
- Cross-platform (Windows, macOS, Linux)
- No additional dependencies needed
- Familiar to most developers

## Test plan

- [ ] Run `npm run check` to verify all checks pass
- [ ] Run `npm run build` to verify binaries are created
- [ ] Run `npm run install` to verify local installation works

Fixes #20