### PR TITLE
feat(list): add version indicators and color coding

### DIFF
--- a/src/internal/config/version.go
+++ b/src/internal/config/version.go
@@ -151,6 +151,11 @@ func FindLocalRuntimesFile() (string, error) {
 	return "", fmt.Errorf("no .dtvem/runtimes.json file found")
 }
 
+// LocalVersion reads the local version for a runtime by walking up the directory tree
+func LocalVersion(runtimeName string) (string, error) {
+	return findLocalVersion(runtimeName)
+}
+
 // GlobalVersion reads the global version for a runtime
 func GlobalVersion(runtimeName string) (string, error) {
 	configPath := GlobalConfigPath()

--- a/src/internal/ui/output.go
+++ b/src/internal/ui/output.go
@@ -81,6 +81,16 @@ func HighlightVersion(version string) string {
 	return color.New(color.FgMagenta, color.Bold).Sprint(version)
 }
 
+// ActiveVersion prints a version string in green (for currently active version)
+func ActiveVersion(version string) string {
+	return color.New(color.FgGreen, color.Bold).Sprint(version)
+}
+
+// DimText prints text in a dimmed/gray color (for inactive items)
+func DimText(text string) string {
+	return color.New(color.Faint).Sprint(text)
+}
+
 // PromptInstall prompts the user to install a missing version.
 // Returns true if the user wants to install, false otherwise.
 // Respects DTVEM_AUTO_INSTALL environment variable:


### PR DESCRIPTION
## Summary

Add visual indicators to distinguish version status in `dtvem list` output:

- 🌐 emoji for global version
- 📍 emoji for local version (from `.dtvem/runtimes.json` in directory tree)
- Green highlighting for active version (local takes priority over global)

## Changes

- Export `LocalVersion()` function in config package
- Add `ActiveVersion()` and `DimText()` helpers in ui package  
- Update `list.go` to show indicators and apply color coding

## Example Output

```
Installed Node.js versions:
    18.0.0
    20.0.0  🌐
    22.0.0  📍    ← green (active)
```

## Test plan

- [x] `dtvem list node` shows emoji indicators
- [x] `dtvem list` shows indicators for all runtimes
- [x] Active version (local > global) shown in green
- [x] All tests pass

Closes #8