### PR TITLE
refactor(runtime): remove hardcoded system paths from DetectInstalled

### DIFF
--- a/src/runtimes/node/provider.go
+++ b/src/runtimes/node/provider.go
@@ -359,25 +359,7 @@ func (p *Provider) DetectInstalled() ([]runtime.DetectedVersion, error) {
 		}
 	}
 
-	// 2. Check common installation locations
-	locations := getNodeInstallLocations()
-	for _, loc := range locations {
-		if _, err := os.Stat(loc); err == nil {
-			if version, err := getNodeVersion(loc); err == nil {
-				if !seen[loc] {
-					detected = append(detected, runtime.DetectedVersion{
-						Version:   version,
-						Path:      loc,
-						Source:    "system",
-						Validated: true,
-					})
-					seen[loc] = true
-				}
-			}
-		}
-	}
-
-	// 3. Check nvm installations
+	// 2. Check nvm installations
 	nvmVersions := findNvmVersions()
 	for _, dv := range nvmVersions {
 		if !seen[dv.Path] {
@@ -386,7 +368,7 @@ func (p *Provider) DetectInstalled() ([]runtime.DetectedVersion, error) {
 		}
 	}
 
-	// 4. Check fnm installations
+	// 3. Check fnm installations
 	fnmVersions := findFnmVersions()
 	for _, dv := range fnmVersions {
 		if !seen[dv.Path] {
@@ -411,34 +393,6 @@ func getNodeVersion(nodePath string) (string, error) {
 	version = strings.TrimPrefix(version, "v")
 
 	return version, nil
-}
-
-// getNodeInstallLocations returns common Node.js installation paths
-func getNodeInstallLocations() []string {
-	home, _ := os.UserHomeDir()
-
-	locations := []string{
-		// Windows
-		`C:\Program Files\nodejs\node.exe`,
-		`C:\Program Files (x86)\nodejs\node.exe`,
-
-		// macOS (Homebrew)
-		"/usr/local/bin/node",
-		"/opt/homebrew/bin/node",
-
-		// Linux
-		"/usr/bin/node",
-		"/usr/local/bin/node",
-	}
-
-	// Add user-specific locations
-	if home != "" {
-		locations = append(locations,
-			filepath.Join(home, ".local", "bin", "node"),
-		)
-	}
-
-	return locations
 }
 
 // findNvmVersions scans nvm directory for installed versions

--- a/src/runtimes/python/provider.go
+++ b/src/runtimes/python/provider.go
@@ -575,25 +575,7 @@ func (p *Provider) DetectInstalled() ([]runtime.DetectedVersion, error) {
 		}
 	}
 
-	// 2. Check common installation locations
-	locations := getPythonInstallLocations()
-	for _, loc := range locations {
-		if _, err := os.Stat(loc); err == nil {
-			if version, err := getPythonVersion(loc); err == nil {
-				if !seen[loc] {
-					detected = append(detected, runtime.DetectedVersion{
-						Version:   version,
-						Path:      loc,
-						Source:    "system",
-						Validated: true,
-					})
-					seen[loc] = true
-				}
-			}
-		}
-	}
-
-	// 3. Check pyenv installations
+	// 2. Check pyenv installations
 	pyenvVersions := findPyenvVersions()
 	for _, dv := range pyenvVersions {
 		if !seen[dv.Path] {
@@ -622,49 +604,6 @@ func getPythonVersion(pythonPath string) (string, error) {
 	}
 
 	return "", fmt.Errorf("could not parse Python version from: %s", version)
-}
-
-// getPythonInstallLocations returns common Python installation paths
-func getPythonInstallLocations() []string {
-	home, _ := os.UserHomeDir()
-
-	locations := []string{
-		// Windows - check multiple Python versions
-		`C:\Python311\python.exe`,
-		`C:\Python310\python.exe`,
-		`C:\Python39\python.exe`,
-		`C:\Python38\python.exe`,
-		`C:\Python37\python.exe`,
-
-		// macOS (Homebrew and system)
-		"/usr/local/bin/python3",
-		"/opt/homebrew/bin/python3",
-		"/usr/bin/python3",
-
-		// Linux
-		"/usr/bin/python3",
-		"/usr/local/bin/python3",
-	}
-
-	// Windows - check LocalAppData\Programs\Python
-	if home != "" {
-		pythonLocalDir := filepath.Join(home, "AppData", "Local", "Programs", "Python")
-		if entries, err := os.ReadDir(pythonLocalDir); err == nil {
-			for _, entry := range entries {
-				if entry.IsDir() {
-					pythonExe := filepath.Join(pythonLocalDir, entry.Name(), "python.exe")
-					locations = append(locations, pythonExe)
-				}
-			}
-		}
-
-		// macOS/Linux user installs
-		locations = append(locations,
-			filepath.Join(home, ".local", "bin", "python3"),
-		)
-	}
-
-	return locations
 }
 
 // findPyenvVersions scans pyenv directory for installed versions

--- a/src/runtimes/ruby/provider.go
+++ b/src/runtimes/ruby/provider.go
@@ -572,25 +572,7 @@ func (p *Provider) DetectInstalled() ([]runtime.DetectedVersion, error) {
 		}
 	}
 
-	// 2. Check common installation locations
-	locations := getRubyInstallLocations()
-	for _, loc := range locations {
-		if _, err := os.Stat(loc); err == nil {
-			if version, err := getRubyVersion(loc); err == nil {
-				if !seen[loc] {
-					detected = append(detected, runtime.DetectedVersion{
-						Version:   version,
-						Path:      loc,
-						Source:    "system",
-						Validated: true,
-					})
-					seen[loc] = true
-				}
-			}
-		}
-	}
-
-	// 3. Check rbenv installations
+	// 2. Check rbenv installations
 	rbenvVersions := findRbenvVersions()
 	for _, dv := range rbenvVersions {
 		if !seen[dv.Path] {
@@ -599,7 +581,7 @@ func (p *Provider) DetectInstalled() ([]runtime.DetectedVersion, error) {
 		}
 	}
 
-	// 4. Check rvm installations
+	// 3. Check rvm installations
 	rvmVersions := findRvmVersions()
 	for _, dv := range rvmVersions {
 		if !seen[dv.Path] {
@@ -608,7 +590,7 @@ func (p *Provider) DetectInstalled() ([]runtime.DetectedVersion, error) {
 		}
 	}
 
-	// 5. Check chruby installations
+	// 4. Check chruby installations
 	chrubyVersions := findChrubyVersions()
 	for _, dv := range chrubyVersions {
 		if !seen[dv.Path] {
@@ -637,37 +619,6 @@ func getRubyVersion(rubyPath string) (string, error) {
 	}
 
 	return "", fmt.Errorf("could not parse Ruby version from: %s", version)
-}
-
-// getRubyInstallLocations returns common Ruby installation paths
-func getRubyInstallLocations() []string {
-	home, _ := os.UserHomeDir()
-
-	locations := []string{
-		// Windows
-		`C:\Ruby33-x64\bin\ruby.exe`,
-		`C:\Ruby32-x64\bin\ruby.exe`,
-		`C:\Ruby31-x64\bin\ruby.exe`,
-		`C:\Ruby30-x64\bin\ruby.exe`,
-
-		// macOS (Homebrew and system)
-		"/usr/local/bin/ruby",
-		"/opt/homebrew/bin/ruby",
-		"/usr/bin/ruby",
-
-		// Linux
-		"/usr/bin/ruby",
-		"/usr/local/bin/ruby",
-	}
-
-	// Add user-specific locations
-	if home != "" {
-		locations = append(locations,
-			filepath.Join(home, ".local", "bin", "ruby"),
-		)
-	}
-
-	return locations
 }
 
 // findRbenvVersions scans rbenv directory for installed versions


### PR DESCRIPTION
## Summary

- Remove redundant hardcoded installation paths from all three runtime providers
- Simplify `DetectInstalled()` to only use PATH detection and version manager detection
- Remove maintenance burden of keeping hardcoded paths up to date

## Removed Functions

| Provider | Function Removed |
|----------|------------------|
| Node.js | `getNodeInstallLocations()` |
| Python | `getPythonInstallLocations()` |
| Ruby | `getRubyInstallLocations()` |

## Rationale

These hardcoded paths were redundant because:

1. **If the install is in PATH** - `LookPathExcludingShims()` already finds it
2. **If the install is NOT in PATH** - It's not usable anyway, no point migrating it

The hardcoded paths also had maintenance problems:
- Incomplete (miss future versions like Python 3.13, Ruby 3.4)
- Don't handle custom installation paths
- Inconsistent across providers
- Add code complexity without value

## Test plan

- [x] All existing tests pass
- [x] Linting passes
- [x] `DetectInstalled()` still detects:
  - System installs in PATH
  - nvm/fnm installed Node.js versions
  - pyenv installed Python versions
  - rbenv/rvm/chruby installed Ruby versions

Closes #124