### PR TITLE
refactor(migration): plugin-style architecture for providers

### DIFF
--- a/src/internal/migration/provider.go
+++ b/src/internal/migration/provider.go
@@ -1,0 +1,46 @@
+// Package migration provides a plugin-style architecture for migrating from
+// other version managers (nvm, pyenv, rbenv, etc.) to dtvem.
+package migration
+
+// Provider defines the interface that all migration providers must implement.
+// Each provider handles detection and cleanup for a specific version manager.
+type Provider interface {
+	// Name returns the identifier for this version manager (e.g., "nvm", "pyenv", "rbenv")
+	Name() string
+
+	// DisplayName returns the human-readable name (e.g., "Node Version Manager (nvm)")
+	DisplayName() string
+
+	// Runtime returns the runtime this provider manages (e.g., "node", "python", "ruby")
+	Runtime() string
+
+	// IsPresent checks if this version manager is installed on the system
+	IsPresent() bool
+
+	// DetectVersions finds all versions installed by this version manager
+	DetectVersions() ([]DetectedVersion, error)
+
+	// CanAutoUninstall returns true if versions can be uninstalled automatically
+	CanAutoUninstall() bool
+
+	// UninstallCommand returns the command to uninstall a specific version
+	// Returns empty string if automatic uninstall is not supported
+	UninstallCommand(version string) string
+
+	// ManualInstructions returns instructions for manual removal
+	// Used when automatic uninstall is not available
+	ManualInstructions() string
+}
+
+// DetectedVersion represents a runtime version found by a migration provider.
+type DetectedVersion struct {
+	Version   string // Version string (e.g., "22.0.0", "3.11.0")
+	Path      string // Path to the executable
+	Source    string // Source/version manager name (e.g., "nvm", "pyenv")
+	Validated bool   // Whether we've verified this version works
+}
+
+// String returns a formatted string representation
+func (dv DetectedVersion) String() string {
+	return "v" + dv.Version + " (" + dv.Source + ") " + dv.Path
+}

--- a/src/internal/migration/provider_test_harness.go
+++ b/src/internal/migration/provider_test_harness.go
@@ -1,0 +1,82 @@
+package migration
+
+import (
+	"testing"
+)
+
+// ProviderTestHarness provides a standardized way to test migration provider implementations.
+// Each provider package should use this harness to ensure consistent behavior.
+type ProviderTestHarness struct {
+	Provider     Provider
+	ExpectedName string
+	Runtime      string
+}
+
+// RunAll runs all standard provider tests.
+func (h *ProviderTestHarness) RunAll(t *testing.T) {
+	t.Run("Name", h.TestName)
+	t.Run("DisplayName", h.TestDisplayName)
+	t.Run("Runtime", h.TestRuntime)
+	t.Run("DetectVersions", h.TestDetectVersions)
+	t.Run("CanAutoUninstall", h.TestCanAutoUninstall)
+	t.Run("ManualInstructions", h.TestManualInstructions)
+}
+
+// TestName verifies the provider returns a valid name.
+func (h *ProviderTestHarness) TestName(t *testing.T) {
+	name := h.Provider.Name()
+	if name == "" {
+		t.Error("Name() returned empty string")
+	}
+	if name != h.ExpectedName {
+		t.Errorf("Name() = %q, want %q", name, h.ExpectedName)
+	}
+}
+
+// TestDisplayName verifies the provider returns a valid display name.
+func (h *ProviderTestHarness) TestDisplayName(t *testing.T) {
+	displayName := h.Provider.DisplayName()
+	if displayName == "" {
+		t.Error("DisplayName() returned empty string")
+	}
+}
+
+// TestRuntime verifies the provider returns the expected runtime.
+func (h *ProviderTestHarness) TestRuntime(t *testing.T) {
+	runtime := h.Provider.Runtime()
+	if runtime != h.Runtime {
+		t.Errorf("Runtime() = %q, want %q", runtime, h.Runtime)
+	}
+}
+
+// TestDetectVersions verifies DetectVersions doesn't error.
+func (h *ProviderTestHarness) TestDetectVersions(t *testing.T) {
+	versions, err := h.Provider.DetectVersions()
+	if err != nil {
+		t.Errorf("DetectVersions() error = %v, want nil", err)
+	}
+	if versions == nil {
+		t.Error("DetectVersions() returned nil, want empty slice")
+	}
+}
+
+// TestCanAutoUninstall verifies the method returns a boolean.
+func (h *ProviderTestHarness) TestCanAutoUninstall(t *testing.T) {
+	canAuto := h.Provider.CanAutoUninstall()
+
+	// If auto uninstall is supported, UninstallCommand should return non-empty
+	if canAuto {
+		cmd := h.Provider.UninstallCommand("1.0.0")
+		if cmd == "" {
+			t.Error("CanAutoUninstall() returns true but UninstallCommand() returns empty")
+		}
+	}
+}
+
+// TestManualInstructions verifies manual instructions are provided.
+func (h *ProviderTestHarness) TestManualInstructions(t *testing.T) {
+	instructions := h.Provider.ManualInstructions()
+	if instructions == "" {
+		t.Error("ManualInstructions() returned empty string")
+	}
+}

--- a/src/internal/migration/registry.go
+++ b/src/internal/migration/registry.go
@@ -1,0 +1,153 @@
+package migration
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Registry manages all registered migration providers.
+type Registry struct {
+	providers map[string]Provider
+	mu        sync.RWMutex
+}
+
+// Global registry instance
+var globalRegistry = &Registry{
+	providers: make(map[string]Provider),
+}
+
+// NewRegistry creates a new migration registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		providers: make(map[string]Provider),
+	}
+}
+
+// Register adds a migration provider to the registry.
+func (r *Registry) Register(provider Provider) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	name := provider.Name()
+	if _, exists := r.providers[name]; exists {
+		return fmt.Errorf("migration provider '%s' is already registered", name)
+	}
+
+	r.providers[name] = provider
+	return nil
+}
+
+// Get retrieves a migration provider by name.
+func (r *Registry) Get(name string) (Provider, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	provider, exists := r.providers[name]
+	if !exists {
+		return nil, fmt.Errorf("migration provider '%s' not found", name)
+	}
+
+	return provider, nil
+}
+
+// GetByRuntime returns all migration providers for a given runtime.
+func (r *Registry) GetByRuntime(runtimeName string) []Provider {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	providers := make([]Provider, 0)
+	for _, provider := range r.providers {
+		if provider.Runtime() == runtimeName {
+			providers = append(providers, provider)
+		}
+	}
+	return providers
+}
+
+// List returns all registered migration provider names.
+func (r *Registry) List() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	names := make([]string, 0, len(r.providers))
+	for name := range r.providers {
+		names = append(names, name)
+	}
+	return names
+}
+
+// GetAll returns all registered providers.
+func (r *Registry) GetAll() []Provider {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	providers := make([]Provider, 0, len(r.providers))
+	for _, provider := range r.providers {
+		providers = append(providers, provider)
+	}
+	return providers
+}
+
+// Has checks if a migration provider is registered.
+func (r *Registry) Has(name string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	_, exists := r.providers[name]
+	return exists
+}
+
+// Unregister removes a migration provider from the registry.
+func (r *Registry) Unregister(name string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.providers[name]; !exists {
+		return fmt.Errorf("migration provider '%s' not found", name)
+	}
+
+	delete(r.providers, name)
+	return nil
+}
+
+// Global registry access functions
+
+// Register adds a provider to the global registry.
+func Register(provider Provider) error {
+	return globalRegistry.Register(provider)
+}
+
+// Get retrieves a provider from the global registry.
+func Get(name string) (Provider, error) {
+	return globalRegistry.Get(name)
+}
+
+// GetByRuntime returns all providers for a runtime from the global registry.
+func GetByRuntime(runtimeName string) []Provider {
+	return globalRegistry.GetByRuntime(runtimeName)
+}
+
+// List returns all registered provider names from the global registry.
+func List() []string {
+	return globalRegistry.List()
+}
+
+// GetAll returns all providers from the global registry.
+func GetAll() []Provider {
+	return globalRegistry.GetAll()
+}
+
+// Has checks if a provider exists in the global registry.
+func Has(name string) bool {
+	return globalRegistry.Has(name)
+}
+
+// Unregister removes a provider from the global registry.
+func Unregister(name string) error {
+	return globalRegistry.Unregister(name)
+}
+
+// GetRegistry returns the global registry instance.
+func GetRegistry() *Registry {
+	return globalRegistry
+}

--- a/src/internal/migration/registry_test.go
+++ b/src/internal/migration/registry_test.go
@@ -1,0 +1,418 @@
+package migration
+
+import (
+	"testing"
+)
+
+// mockProvider is a minimal test implementation of the Provider interface.
+type mockProvider struct {
+	name             string
+	displayName      string
+	runtime          string
+	present          bool
+	canAutoUninstall bool
+}
+
+func (m *mockProvider) Name() string                               { return m.name }
+func (m *mockProvider) DisplayName() string                        { return m.displayName }
+func (m *mockProvider) Runtime() string                            { return m.runtime }
+func (m *mockProvider) IsPresent() bool                            { return m.present }
+func (m *mockProvider) DetectVersions() ([]DetectedVersion, error) { return nil, nil }
+func (m *mockProvider) CanAutoUninstall() bool                     { return m.canAutoUninstall }
+func (m *mockProvider) UninstallCommand(version string) string     { return "" }
+func (m *mockProvider) ManualInstructions() string                 { return "" }
+
+func TestNewRegistry(t *testing.T) {
+	r := NewRegistry()
+	if r == nil {
+		t.Fatal("NewRegistry() returned nil")
+	}
+	if r.providers == nil {
+		t.Error("NewRegistry() did not initialize providers map")
+	}
+	if len(r.providers) != 0 {
+		t.Errorf("NewRegistry() providers map has %d entries, want 0", len(r.providers))
+	}
+}
+
+func TestRegistry_Register(t *testing.T) {
+	tests := []struct {
+		name        string
+		providers   []*mockProvider
+		expectError bool
+	}{
+		{
+			name: "register single provider",
+			providers: []*mockProvider{
+				{name: "test", displayName: "Test", runtime: "node"},
+			},
+			expectError: false,
+		},
+		{
+			name: "register multiple providers",
+			providers: []*mockProvider{
+				{name: "test1", displayName: "Test 1", runtime: "node"},
+				{name: "test2", displayName: "Test 2", runtime: "python"},
+			},
+			expectError: false,
+		},
+		{
+			name: "register duplicate provider",
+			providers: []*mockProvider{
+				{name: "test", displayName: "Test 1", runtime: "node"},
+				{name: "test", displayName: "Test 2", runtime: "node"},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewRegistry()
+			var err error
+			for _, p := range tt.providers {
+				err = r.Register(p)
+			}
+
+			if tt.expectError && err == nil {
+				t.Error("Register() expected error, got nil")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Register() unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestRegistry_Get(t *testing.T) {
+	r := NewRegistry()
+	provider := &mockProvider{name: "test", displayName: "Test", runtime: "node"}
+	if err := r.Register(provider); err != nil {
+		t.Fatalf("Failed to register provider: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		searchName  string
+		expectError bool
+	}{
+		{
+			name:        "get existing provider",
+			searchName:  "test",
+			expectError: false,
+		},
+		{
+			name:        "get non-existent provider",
+			searchName:  "nonexistent",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := r.Get(tt.searchName)
+
+			if tt.expectError {
+				if err == nil {
+					t.Error("Get() expected error, got nil")
+				}
+				if p != nil {
+					t.Error("Get() expected nil provider on error")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Get() unexpected error: %v", err)
+				}
+				if p == nil {
+					t.Error("Get() returned nil provider")
+				}
+				if p.Name() != tt.searchName {
+					t.Errorf("Get() returned provider with name %q, want %q", p.Name(), tt.searchName)
+				}
+			}
+		})
+	}
+}
+
+func TestRegistry_GetByRuntime(t *testing.T) {
+	r := NewRegistry()
+
+	providers := []*mockProvider{
+		{name: "nvm", displayName: "nvm", runtime: "node"},
+		{name: "fnm", displayName: "fnm", runtime: "node"},
+		{name: "pyenv", displayName: "pyenv", runtime: "python"},
+		{name: "rbenv", displayName: "rbenv", runtime: "ruby"},
+	}
+
+	for _, p := range providers {
+		if err := r.Register(p); err != nil {
+			t.Fatalf("Failed to register provider: %v", err)
+		}
+	}
+
+	tests := []struct {
+		name     string
+		runtime  string
+		expected int
+	}{
+		{
+			name:     "get node providers",
+			runtime:  "node",
+			expected: 2,
+		},
+		{
+			name:     "get python providers",
+			runtime:  "python",
+			expected: 1,
+		},
+		{
+			name:     "get ruby providers",
+			runtime:  "ruby",
+			expected: 1,
+		},
+		{
+			name:     "get non-existent runtime",
+			runtime:  "golang",
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := r.GetByRuntime(tt.runtime)
+			if len(result) != tt.expected {
+				t.Errorf("GetByRuntime(%q) returned %d providers, want %d", tt.runtime, len(result), tt.expected)
+			}
+
+			// Verify all returned providers are for the correct runtime
+			for _, p := range result {
+				if p.Runtime() != tt.runtime {
+					t.Errorf("GetByRuntime(%q) returned provider with runtime %q", tt.runtime, p.Runtime())
+				}
+			}
+		})
+	}
+}
+
+func TestRegistry_List(t *testing.T) {
+	tests := []struct {
+		name      string
+		providers []*mockProvider
+		expected  int
+	}{
+		{
+			name:      "empty registry",
+			providers: []*mockProvider{},
+			expected:  0,
+		},
+		{
+			name: "single provider",
+			providers: []*mockProvider{
+				{name: "test", displayName: "Test", runtime: "node"},
+			},
+			expected: 1,
+		},
+		{
+			name: "multiple providers",
+			providers: []*mockProvider{
+				{name: "test1", displayName: "Test 1", runtime: "node"},
+				{name: "test2", displayName: "Test 2", runtime: "python"},
+				{name: "test3", displayName: "Test 3", runtime: "ruby"},
+			},
+			expected: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewRegistry()
+			for _, p := range tt.providers {
+				if err := r.Register(p); err != nil {
+					t.Fatalf("Failed to register provider: %v", err)
+				}
+			}
+
+			list := r.List()
+			if len(list) != tt.expected {
+				t.Errorf("List() returned %d names, want %d", len(list), tt.expected)
+			}
+
+			// Verify all registered providers are in the list
+			for _, p := range tt.providers {
+				found := false
+				for _, name := range list {
+					if name == p.name {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("List() missing provider %q", p.name)
+				}
+			}
+		})
+	}
+}
+
+func TestRegistry_GetAll(t *testing.T) {
+	tests := []struct {
+		name      string
+		providers []*mockProvider
+		expected  int
+	}{
+		{
+			name:      "empty registry",
+			providers: []*mockProvider{},
+			expected:  0,
+		},
+		{
+			name: "multiple providers",
+			providers: []*mockProvider{
+				{name: "test1", displayName: "Test 1", runtime: "node"},
+				{name: "test2", displayName: "Test 2", runtime: "python"},
+			},
+			expected: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewRegistry()
+			for _, p := range tt.providers {
+				if err := r.Register(p); err != nil {
+					t.Fatalf("Failed to register provider: %v", err)
+				}
+			}
+
+			all := r.GetAll()
+			if len(all) != tt.expected {
+				t.Errorf("GetAll() returned %d providers, want %d", len(all), tt.expected)
+			}
+		})
+	}
+}
+
+func TestRegistry_Has(t *testing.T) {
+	r := NewRegistry()
+	provider := &mockProvider{name: "test", displayName: "Test", runtime: "node"}
+	if err := r.Register(provider); err != nil {
+		t.Fatalf("Failed to register provider: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		searchName string
+		expected   bool
+	}{
+		{
+			name:       "existing provider",
+			searchName: "test",
+			expected:   true,
+		},
+		{
+			name:       "non-existent provider",
+			searchName: "nonexistent",
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := r.Has(tt.searchName)
+			if result != tt.expected {
+				t.Errorf("Has(%q) = %v, want %v", tt.searchName, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRegistry_Unregister(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func(*Registry)
+		unregister  string
+		expectError bool
+	}{
+		{
+			name: "unregister existing provider",
+			setup: func(r *Registry) {
+				_ = r.Register(&mockProvider{name: "test", displayName: "Test", runtime: "node"})
+			},
+			unregister:  "test",
+			expectError: false,
+		},
+		{
+			name:        "unregister non-existent provider",
+			setup:       func(r *Registry) {},
+			unregister:  "nonexistent",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewRegistry()
+			tt.setup(r)
+
+			err := r.Unregister(tt.unregister)
+
+			if tt.expectError && err == nil {
+				t.Error("Unregister() expected error, got nil")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Unregister() unexpected error: %v", err)
+			}
+
+			// Verify provider is actually removed
+			if !tt.expectError && r.Has(tt.unregister) {
+				t.Errorf("Unregister() did not remove provider %q", tt.unregister)
+			}
+		})
+	}
+}
+
+func TestRegistry_ConcurrentAccess(t *testing.T) {
+	// This test verifies that the registry is thread-safe
+	r := NewRegistry()
+	provider := &mockProvider{name: "test", displayName: "Test", runtime: "node"}
+
+	// Register in one goroutine
+	done := make(chan bool)
+	go func() {
+		_ = r.Register(provider)
+		done <- true
+	}()
+
+	// Read in another goroutine
+	go func() {
+		r.Has("test")
+		r.List()
+		r.GetByRuntime("node")
+		done <- true
+	}()
+
+	// Wait for both goroutines
+	<-done
+	<-done
+
+	// Verify the provider was registered
+	if !r.Has("test") {
+		t.Error("Concurrent Register() did not work correctly")
+	}
+}
+
+func TestDetectedVersion_String(t *testing.T) {
+	dv := DetectedVersion{
+		Version:   "22.0.0",
+		Path:      "/path/to/node",
+		Source:    "nvm",
+		Validated: true,
+	}
+
+	result := dv.String()
+	expected := "v22.0.0 (nvm) /path/to/node"
+
+	if result != expected {
+		t.Errorf("DetectedVersion.String() = %q, want %q", result, expected)
+	}
+}

--- a/src/main.go
+++ b/src/main.go
@@ -7,6 +7,22 @@ import (
 	_ "github.com/dtvem/dtvem/src/runtimes/node"
 	_ "github.com/dtvem/dtvem/src/runtimes/python"
 	_ "github.com/dtvem/dtvem/src/runtimes/ruby"
+
+	// Import migration providers to register them
+	// Node.js migration providers
+	_ "github.com/dtvem/dtvem/src/migrations/node/fnm"
+	_ "github.com/dtvem/dtvem/src/migrations/node/nvm"
+	_ "github.com/dtvem/dtvem/src/migrations/node/system"
+
+	// Python migration providers
+	_ "github.com/dtvem/dtvem/src/migrations/python/pyenv"
+	_ "github.com/dtvem/dtvem/src/migrations/python/system"
+
+	// Ruby migration providers
+	_ "github.com/dtvem/dtvem/src/migrations/ruby/chruby"
+	_ "github.com/dtvem/dtvem/src/migrations/ruby/rbenv"
+	_ "github.com/dtvem/dtvem/src/migrations/ruby/rvm"
+	_ "github.com/dtvem/dtvem/src/migrations/ruby/system"
 )
 
 func main() {

--- a/src/migrations/node/fnm/provider.go
+++ b/src/migrations/node/fnm/provider.go
@@ -1,0 +1,132 @@
+// Package fnm provides a migration provider for Fast Node Manager (fnm).
+package fnm
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/dtvem/dtvem/src/internal/migration"
+)
+
+// Provider implements the migration.Provider interface for fnm.
+type Provider struct{}
+
+// NewProvider creates a new fnm migration provider.
+func NewProvider() *Provider {
+	return &Provider{}
+}
+
+// Name returns the identifier for this version manager.
+func (p *Provider) Name() string {
+	return "fnm"
+}
+
+// DisplayName returns the human-readable name.
+func (p *Provider) DisplayName() string {
+	return "Fast Node Manager (fnm)"
+}
+
+// Runtime returns the runtime this provider manages.
+func (p *Provider) Runtime() string {
+	return "node"
+}
+
+// IsPresent checks if fnm is installed on the system.
+func (p *Provider) IsPresent() bool {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+
+	// fnm stores versions in various locations
+	fnmDirs := []string{
+		filepath.Join(home, ".local", "share", "fnm", "node-versions"),
+		filepath.Join(home, ".fnm", "node-versions"),
+		filepath.Join(home, "Library", "Application Support", "fnm", "node-versions"), // macOS
+	}
+
+	for _, fnmDir := range fnmDirs {
+		if _, err := os.Stat(fnmDir); err == nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+// DetectVersions finds all versions installed by fnm.
+func (p *Provider) DetectVersions() ([]migration.DetectedVersion, error) {
+	detected := make([]migration.DetectedVersion, 0)
+	home, err := os.UserHomeDir()
+	if err != nil {
+		// If we can't get home dir, just return empty list (fnm won't be found anyway)
+		return detected, nil //nolint:nilerr // Expected: no home dir means no fnm
+	}
+
+	// fnm stores versions in ~/.local/share/fnm/node-versions or similar
+	fnmDirs := []string{
+		filepath.Join(home, ".local", "share", "fnm", "node-versions"),
+		filepath.Join(home, ".fnm", "node-versions"),
+		filepath.Join(home, "Library", "Application Support", "fnm", "node-versions"), // macOS
+	}
+
+	for _, fnmDir := range fnmDirs {
+		if entries, err := os.ReadDir(fnmDir); err == nil {
+			for _, entry := range entries {
+				if entry.IsDir() {
+					versionDir := filepath.Join(fnmDir, entry.Name())
+
+					// Try both Unix and Windows paths
+					nodePaths := []string{
+						filepath.Join(versionDir, "installation", "bin", "node"),
+						filepath.Join(versionDir, "installation", "node.exe"),
+						filepath.Join(versionDir, "bin", "node"),
+						filepath.Join(versionDir, "node.exe"),
+					}
+
+					for _, nodePath := range nodePaths {
+						if _, err := os.Stat(nodePath); err == nil {
+							version := strings.TrimPrefix(entry.Name(), "v")
+
+							detected = append(detected, migration.DetectedVersion{
+								Version:   version,
+								Path:      nodePath,
+								Source:    "fnm",
+								Validated: false,
+							})
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return detected, nil
+}
+
+// CanAutoUninstall returns true because fnm supports automatic uninstall.
+func (p *Provider) CanAutoUninstall() bool {
+	return true
+}
+
+// UninstallCommand returns the command to uninstall a specific version.
+func (p *Provider) UninstallCommand(version string) string {
+	return fmt.Sprintf("fnm uninstall %s", version)
+}
+
+// ManualInstructions returns instructions for manual removal.
+func (p *Provider) ManualInstructions() string {
+	return "To manually remove an fnm-installed Node.js version:\n" +
+		"  1. Run: fnm uninstall <version>\n" +
+		"  2. Or manually delete the version directory from ~/.local/share/fnm/node-versions/"
+}
+
+// init registers the fnm provider on package load.
+func init() {
+	if err := migration.Register(NewProvider()); err != nil {
+		panic(fmt.Sprintf("failed to register fnm migration provider: %v", err))
+	}
+}

--- a/src/migrations/node/fnm/provider_test.go
+++ b/src/migrations/node/fnm/provider_test.go
@@ -1,0 +1,37 @@
+package fnm
+
+import (
+	"testing"
+
+	"github.com/dtvem/dtvem/src/internal/migration"
+)
+
+func TestProvider(t *testing.T) {
+	harness := &migration.ProviderTestHarness{
+		Provider:     NewProvider(),
+		ExpectedName: "fnm",
+		Runtime:      "node",
+	}
+	harness.RunAll(t)
+}
+
+func TestProvider_UninstallCommand(t *testing.T) {
+	p := NewProvider()
+
+	tests := []struct {
+		version  string
+		expected string
+	}{
+		{version: "22.0.0", expected: "fnm uninstall 22.0.0"},
+		{version: "18.16.0", expected: "fnm uninstall 18.16.0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			result := p.UninstallCommand(tt.version)
+			if result != tt.expected {
+				t.Errorf("UninstallCommand(%q) = %q, want %q", tt.version, result, tt.expected)
+			}
+		})
+	}
+}

--- a/src/migrations/node/nvm/provider.go
+++ b/src/migrations/node/nvm/provider.go
@@ -1,0 +1,139 @@
+// Package nvm provides a migration provider for Node Version Manager (nvm).
+package nvm
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/dtvem/dtvem/src/internal/migration"
+)
+
+// Provider implements the migration.Provider interface for nvm.
+type Provider struct{}
+
+// NewProvider creates a new nvm migration provider.
+func NewProvider() *Provider {
+	return &Provider{}
+}
+
+// Name returns the identifier for this version manager.
+func (p *Provider) Name() string {
+	return "nvm"
+}
+
+// DisplayName returns the human-readable name.
+func (p *Provider) DisplayName() string {
+	return "Node Version Manager (nvm)"
+}
+
+// Runtime returns the runtime this provider manages.
+func (p *Provider) Runtime() string {
+	return "node"
+}
+
+// IsPresent checks if nvm is installed on the system.
+func (p *Provider) IsPresent() bool {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+
+	// Check Unix-style nvm directory
+	unixDir := filepath.Join(home, ".nvm", "versions", "node")
+	if _, err := os.Stat(unixDir); err == nil {
+		return true
+	}
+
+	// Check Windows nvm directory
+	winDir := filepath.Join(home, "AppData", "Roaming", "nvm")
+	if _, err := os.Stat(winDir); err == nil {
+		return true
+	}
+
+	return false
+}
+
+// DetectVersions finds all versions installed by nvm.
+func (p *Provider) DetectVersions() ([]migration.DetectedVersion, error) {
+	detected := make([]migration.DetectedVersion, 0)
+	home, err := os.UserHomeDir()
+	if err != nil {
+		// If we can't get home dir, just return empty list (nvm won't be found anyway)
+		return detected, nil //nolint:nilerr // Expected: no home dir means no nvm
+	}
+
+	// Check Unix-style nvm directory
+	nvmDir := filepath.Join(home, ".nvm", "versions", "node")
+	if entries, err := os.ReadDir(nvmDir); err == nil {
+		for _, entry := range entries {
+			if entry.IsDir() {
+				versionDir := filepath.Join(nvmDir, entry.Name())
+				nodePath := filepath.Join(versionDir, "bin", "node")
+
+				if _, err := os.Stat(nodePath); err == nil {
+					// Extract version from directory name (e.g., "v22.0.0" -> "22.0.0")
+					version := strings.TrimPrefix(entry.Name(), "v")
+
+					detected = append(detected, migration.DetectedVersion{
+						Version:   version,
+						Path:      nodePath,
+						Source:    "nvm",
+						Validated: false,
+					})
+				}
+			}
+		}
+	}
+
+	// Check Windows nvm directory
+	nvmWinDir := filepath.Join(home, "AppData", "Roaming", "nvm")
+	if entries, err := os.ReadDir(nvmWinDir); err == nil {
+		versionRegex := regexp.MustCompile(`^v?\d+\.\d+\.\d+$`)
+		for _, entry := range entries {
+			if entry.IsDir() && versionRegex.MatchString(entry.Name()) {
+				versionDir := filepath.Join(nvmWinDir, entry.Name())
+				nodePath := filepath.Join(versionDir, "node.exe")
+
+				if _, err := os.Stat(nodePath); err == nil {
+					version := strings.TrimPrefix(entry.Name(), "v")
+
+					detected = append(detected, migration.DetectedVersion{
+						Version:   version,
+						Path:      nodePath,
+						Source:    "nvm",
+						Validated: false,
+					})
+				}
+			}
+		}
+	}
+
+	return detected, nil
+}
+
+// CanAutoUninstall returns true because nvm supports automatic uninstall.
+func (p *Provider) CanAutoUninstall() bool {
+	return true
+}
+
+// UninstallCommand returns the command to uninstall a specific version.
+func (p *Provider) UninstallCommand(version string) string {
+	return fmt.Sprintf("nvm uninstall %s", version)
+}
+
+// ManualInstructions returns instructions for manual removal.
+func (p *Provider) ManualInstructions() string {
+	return "To manually remove an nvm-installed Node.js version:\n" +
+		"  1. Run: nvm uninstall <version>\n" +
+		"  2. Or manually delete the version directory from ~/.nvm/versions/node/"
+}
+
+// init registers the nvm provider on package load.
+func init() {
+	if err := migration.Register(NewProvider()); err != nil {
+		panic(fmt.Sprintf("failed to register nvm migration provider: %v", err))
+	}
+}

--- a/src/migrations/node/nvm/provider_test.go
+++ b/src/migrations/node/nvm/provider_test.go
@@ -1,0 +1,99 @@
+package nvm
+
+import (
+	"testing"
+)
+
+func TestProvider_Name(t *testing.T) {
+	p := NewProvider()
+	if name := p.Name(); name != "nvm" {
+		t.Errorf("Name() = %q, want %q", name, "nvm")
+	}
+}
+
+func TestProvider_DisplayName(t *testing.T) {
+	p := NewProvider()
+	expected := "Node Version Manager (nvm)"
+	if name := p.DisplayName(); name != expected {
+		t.Errorf("DisplayName() = %q, want %q", name, expected)
+	}
+}
+
+func TestProvider_Runtime(t *testing.T) {
+	p := NewProvider()
+	if runtime := p.Runtime(); runtime != "node" {
+		t.Errorf("Runtime() = %q, want %q", runtime, "node")
+	}
+}
+
+func TestProvider_CanAutoUninstall(t *testing.T) {
+	p := NewProvider()
+	if !p.CanAutoUninstall() {
+		t.Error("CanAutoUninstall() = false, want true")
+	}
+}
+
+func TestProvider_UninstallCommand(t *testing.T) {
+	p := NewProvider()
+
+	tests := []struct {
+		version  string
+		expected string
+	}{
+		{version: "22.0.0", expected: "nvm uninstall 22.0.0"},
+		{version: "18.16.0", expected: "nvm uninstall 18.16.0"},
+		{version: "20.10.0", expected: "nvm uninstall 20.10.0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			result := p.UninstallCommand(tt.version)
+			if result != tt.expected {
+				t.Errorf("UninstallCommand(%q) = %q, want %q", tt.version, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestProvider_ManualInstructions(t *testing.T) {
+	p := NewProvider()
+	instructions := p.ManualInstructions()
+
+	if instructions == "" {
+		t.Error("ManualInstructions() returned empty string")
+	}
+
+	// Check that instructions mention nvm
+	if !containsSubstring(instructions, "nvm") {
+		t.Error("ManualInstructions() should mention nvm")
+	}
+}
+
+func TestProvider_DetectVersions_NoInstallation(t *testing.T) {
+	p := NewProvider()
+
+	// DetectVersions should not error even if nvm is not installed
+	versions, err := p.DetectVersions()
+	if err != nil {
+		t.Errorf("DetectVersions() error = %v, want nil", err)
+	}
+
+	// The result may be empty if nvm is not installed, which is fine
+	if versions == nil {
+		t.Error("DetectVersions() returned nil, want empty slice")
+	}
+}
+
+// containsSubstring checks if s contains substr.
+func containsSubstring(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstringHelper(s, substr))
+}
+
+func containsSubstringHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/src/migrations/node/system/provider.go
+++ b/src/migrations/node/system/provider.go
@@ -1,0 +1,121 @@
+// Package system provides a migration provider for system-installed Node.js.
+package system
+
+import (
+	"os/exec"
+	"regexp"
+	goruntime "runtime"
+	"strings"
+
+	"github.com/dtvem/dtvem/src/internal/migration"
+	"github.com/dtvem/dtvem/src/internal/path"
+)
+
+// Provider implements the migration.Provider interface for system-installed Node.js.
+type Provider struct{}
+
+// NewProvider creates a new system Node.js migration provider.
+func NewProvider() *Provider {
+	return &Provider{}
+}
+
+// Name returns the identifier for this provider.
+func (p *Provider) Name() string {
+	return "system-node"
+}
+
+// DisplayName returns the human-readable name.
+func (p *Provider) DisplayName() string {
+	return "System Node.js"
+}
+
+// Runtime returns the runtime this provider manages.
+func (p *Provider) Runtime() string {
+	return "node"
+}
+
+// IsPresent checks if a system-installed Node.js exists in PATH.
+func (p *Provider) IsPresent() bool {
+	return path.LookPathExcludingShims("node") != ""
+}
+
+// DetectVersions finds system-installed Node.js in PATH.
+func (p *Provider) DetectVersions() ([]migration.DetectedVersion, error) {
+	detected := make([]migration.DetectedVersion, 0)
+
+	nodePath := path.LookPathExcludingShims("node")
+	if nodePath == "" {
+		return detected, nil
+	}
+
+	version := p.getVersion(nodePath)
+	if version != "" {
+		detected = append(detected, migration.DetectedVersion{
+			Version:   version,
+			Path:      nodePath,
+			Source:    "system",
+			Validated: true,
+		})
+	}
+
+	return detected, nil
+}
+
+// getVersion runs node --version and extracts the version number.
+func (p *Provider) getVersion(execPath string) string {
+	cmd := exec.Command(execPath, "--version")
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+
+	version := strings.TrimSpace(string(output))
+	re := regexp.MustCompile(`v?(\d+\.\d+\.\d+)`)
+	matches := re.FindStringSubmatch(version)
+	if len(matches) >= 2 {
+		return matches[1]
+	}
+
+	return ""
+}
+
+// CanAutoUninstall returns false because system installs require manual removal.
+func (p *Provider) CanAutoUninstall() bool {
+	return false
+}
+
+// UninstallCommand returns an empty string because system installs need manual removal.
+func (p *Provider) UninstallCommand(version string) string {
+	return ""
+}
+
+// ManualInstructions returns OS-specific uninstall instructions.
+func (p *Provider) ManualInstructions() string {
+	switch goruntime.GOOS {
+	case "windows":
+		return "To uninstall:\n" +
+			"  1. Open Settings \u2192 Apps \u2192 Installed apps\n" +
+			"  2. Search for Node.js\n" +
+			"  3. Click Uninstall\n" +
+			"  Or use PowerShell to find and run the uninstaller"
+	case "darwin":
+		return "To uninstall:\n" +
+			"  If installed via Homebrew: brew uninstall node\n" +
+			"  If installed via package: check /Applications or use the installer's uninstaller\n" +
+			"  Or manually remove from /usr/local/bin/"
+	case "linux":
+		return "To uninstall:\n" +
+			"  If installed via apt: sudo apt remove nodejs\n" +
+			"  If installed via yum: sudo yum remove nodejs\n" +
+			"  If installed via dnf: sudo dnf remove nodejs"
+	default:
+		return "Please use your system's package manager to uninstall Node.js"
+	}
+}
+
+// init registers the system provider on package load.
+func init() {
+	if err := migration.Register(NewProvider()); err != nil {
+		// Ignore registration errors (may already be registered)
+	}
+}

--- a/src/migrations/node/system/provider_test.go
+++ b/src/migrations/node/system/provider_test.go
@@ -1,0 +1,41 @@
+package system
+
+import (
+	"testing"
+
+	"github.com/dtvem/dtvem/src/internal/migration"
+)
+
+func TestProvider(t *testing.T) {
+	harness := &migration.ProviderTestHarness{
+		Provider:     NewProvider(),
+		ExpectedName: "system-node",
+		Runtime:      "node",
+	}
+	harness.RunAll(t)
+}
+
+func TestProvider_CanAutoUninstall(t *testing.T) {
+	p := NewProvider()
+
+	if p.CanAutoUninstall() {
+		t.Error("CanAutoUninstall() = true, want false")
+	}
+}
+
+func TestProvider_UninstallCommand(t *testing.T) {
+	p := NewProvider()
+
+	if cmd := p.UninstallCommand("22.0.0"); cmd != "" {
+		t.Errorf("UninstallCommand() = %q, want empty string", cmd)
+	}
+}
+
+func TestProvider_ManualInstructions(t *testing.T) {
+	p := NewProvider()
+
+	instructions := p.ManualInstructions()
+	if instructions == "" {
+		t.Error("ManualInstructions() returned empty string")
+	}
+}

--- a/src/migrations/python/pyenv/provider.go
+++ b/src/migrations/python/pyenv/provider.go
@@ -1,0 +1,143 @@
+// Package pyenv provides a migration provider for pyenv.
+package pyenv
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/dtvem/dtvem/src/internal/migration"
+)
+
+// Provider implements the migration.Provider interface for pyenv.
+type Provider struct{}
+
+// NewProvider creates a new pyenv migration provider.
+func NewProvider() *Provider {
+	return &Provider{}
+}
+
+// Name returns the identifier for this version manager.
+func (p *Provider) Name() string {
+	return "pyenv"
+}
+
+// DisplayName returns the human-readable name.
+func (p *Provider) DisplayName() string {
+	return "pyenv"
+}
+
+// Runtime returns the runtime this provider manages.
+func (p *Provider) Runtime() string {
+	return "python"
+}
+
+// IsPresent checks if pyenv is installed on the system.
+func (p *Provider) IsPresent() bool {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+
+	// Check Unix-style pyenv directory
+	unixDir := filepath.Join(home, ".pyenv", "versions")
+	if _, err := os.Stat(unixDir); err == nil {
+		return true
+	}
+
+	// Check Windows pyenv directory
+	winDir := filepath.Join(home, ".pyenv", "pyenv-win", "versions")
+	if _, err := os.Stat(winDir); err == nil {
+		return true
+	}
+
+	return false
+}
+
+// DetectVersions finds all versions installed by pyenv.
+func (p *Provider) DetectVersions() ([]migration.DetectedVersion, error) {
+	detected := make([]migration.DetectedVersion, 0)
+	home, err := os.UserHomeDir()
+	if err != nil {
+		// If we can't get home dir, just return empty list (pyenv won't be found anyway)
+		return detected, nil //nolint:nilerr // Expected: no home dir means no pyenv
+	}
+
+	versionRegex := regexp.MustCompile(`^\d+\.\d+\.\d+`)
+
+	// Check Unix-style pyenv directory
+	pyenvDir := filepath.Join(home, ".pyenv", "versions")
+	if entries, err := os.ReadDir(pyenvDir); err == nil {
+		for _, entry := range entries {
+			if entry.IsDir() && versionRegex.MatchString(entry.Name()) {
+				versionDir := filepath.Join(pyenvDir, entry.Name())
+
+				// Try both Unix and Windows paths
+				pythonPaths := []string{
+					filepath.Join(versionDir, "bin", "python"),
+					filepath.Join(versionDir, "bin", "python3"),
+					filepath.Join(versionDir, "python.exe"),
+				}
+
+				for _, pythonPath := range pythonPaths {
+					if _, err := os.Stat(pythonPath); err == nil {
+						detected = append(detected, migration.DetectedVersion{
+							Version:   entry.Name(),
+							Path:      pythonPath,
+							Source:    "pyenv",
+							Validated: false,
+						})
+						break
+					}
+				}
+			}
+		}
+	}
+
+	// Check Windows pyenv directory
+	pyenvWinDir := filepath.Join(home, ".pyenv", "pyenv-win", "versions")
+	if entries, err := os.ReadDir(pyenvWinDir); err == nil {
+		for _, entry := range entries {
+			if entry.IsDir() && versionRegex.MatchString(entry.Name()) {
+				versionDir := filepath.Join(pyenvWinDir, entry.Name())
+				pythonPath := filepath.Join(versionDir, "python.exe")
+
+				if _, err := os.Stat(pythonPath); err == nil {
+					detected = append(detected, migration.DetectedVersion{
+						Version:   entry.Name(),
+						Path:      pythonPath,
+						Source:    "pyenv",
+						Validated: false,
+					})
+				}
+			}
+		}
+	}
+
+	return detected, nil
+}
+
+// CanAutoUninstall returns true because pyenv supports automatic uninstall.
+func (p *Provider) CanAutoUninstall() bool {
+	return true
+}
+
+// UninstallCommand returns the command to uninstall a specific version.
+func (p *Provider) UninstallCommand(version string) string {
+	return fmt.Sprintf("pyenv uninstall %s", version)
+}
+
+// ManualInstructions returns instructions for manual removal.
+func (p *Provider) ManualInstructions() string {
+	return "To manually remove a pyenv-installed Python version:\n" +
+		"  1. Run: pyenv uninstall <version>\n" +
+		"  2. Or manually delete the version directory from ~/.pyenv/versions/"
+}
+
+// init registers the pyenv provider on package load.
+func init() {
+	if err := migration.Register(NewProvider()); err != nil {
+		panic(fmt.Sprintf("failed to register pyenv migration provider: %v", err))
+	}
+}

--- a/src/migrations/python/pyenv/provider_test.go
+++ b/src/migrations/python/pyenv/provider_test.go
@@ -1,0 +1,37 @@
+package pyenv
+
+import (
+	"testing"
+
+	"github.com/dtvem/dtvem/src/internal/migration"
+)
+
+func TestProvider(t *testing.T) {
+	harness := &migration.ProviderTestHarness{
+		Provider:     NewProvider(),
+		ExpectedName: "pyenv",
+		Runtime:      "python",
+	}
+	harness.RunAll(t)
+}
+
+func TestProvider_UninstallCommand(t *testing.T) {
+	p := NewProvider()
+
+	tests := []struct {
+		version  string
+		expected string
+	}{
+		{version: "3.11.0", expected: "pyenv uninstall 3.11.0"},
+		{version: "3.12.0", expected: "pyenv uninstall 3.12.0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			result := p.UninstallCommand(tt.version)
+			if result != tt.expected {
+				t.Errorf("UninstallCommand(%q) = %q, want %q", tt.version, result, tt.expected)
+			}
+		})
+	}
+}

--- a/src/migrations/python/system/provider.go
+++ b/src/migrations/python/system/provider.go
@@ -1,0 +1,130 @@
+// Package system provides a migration provider for system-installed Python.
+package system
+
+import (
+	"os/exec"
+	"regexp"
+	goruntime "runtime"
+	"strings"
+
+	"github.com/dtvem/dtvem/src/internal/migration"
+	"github.com/dtvem/dtvem/src/internal/path"
+)
+
+// Provider implements the migration.Provider interface for system-installed Python.
+type Provider struct{}
+
+// NewProvider creates a new system Python migration provider.
+func NewProvider() *Provider {
+	return &Provider{}
+}
+
+// Name returns the identifier for this provider.
+func (p *Provider) Name() string {
+	return "system-python"
+}
+
+// DisplayName returns the human-readable name.
+func (p *Provider) DisplayName() string {
+	return "System Python"
+}
+
+// Runtime returns the runtime this provider manages.
+func (p *Provider) Runtime() string {
+	return "python"
+}
+
+// IsPresent checks if a system-installed Python exists in PATH.
+func (p *Provider) IsPresent() bool {
+	for _, cmd := range []string{"python3", "python"} {
+		if path.LookPathExcludingShims(cmd) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// DetectVersions finds system-installed Python in PATH.
+func (p *Provider) DetectVersions() ([]migration.DetectedVersion, error) {
+	detected := make([]migration.DetectedVersion, 0)
+	seen := make(map[string]bool)
+
+	for _, cmd := range []string{"python3", "python"} {
+		pythonPath := path.LookPathExcludingShims(cmd)
+		if pythonPath == "" || seen[pythonPath] {
+			continue
+		}
+		seen[pythonPath] = true
+
+		version := p.getVersion(pythonPath)
+		if version != "" {
+			detected = append(detected, migration.DetectedVersion{
+				Version:   version,
+				Path:      pythonPath,
+				Source:    "system",
+				Validated: true,
+			})
+		}
+	}
+
+	return detected, nil
+}
+
+// getVersion runs python --version and extracts the version number.
+func (p *Provider) getVersion(execPath string) string {
+	cmd := exec.Command(execPath, "--version")
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+
+	version := strings.TrimSpace(string(output))
+	re := regexp.MustCompile(`Python\s+(\d+\.\d+\.\d+)`)
+	matches := re.FindStringSubmatch(version)
+	if len(matches) >= 2 {
+		return matches[1]
+	}
+
+	return ""
+}
+
+// CanAutoUninstall returns false because system installs require manual removal.
+func (p *Provider) CanAutoUninstall() bool {
+	return false
+}
+
+// UninstallCommand returns an empty string because system installs need manual removal.
+func (p *Provider) UninstallCommand(version string) string {
+	return ""
+}
+
+// ManualInstructions returns OS-specific uninstall instructions.
+func (p *Provider) ManualInstructions() string {
+	switch goruntime.GOOS {
+	case "windows":
+		return "To uninstall:\n" +
+			"  1. Open Settings \u2192 Apps \u2192 Installed apps\n" +
+			"  2. Search for Python\n" +
+			"  3. Click Uninstall\n" +
+			"  Or use PowerShell to find and run the uninstaller"
+	case "darwin":
+		return "To uninstall:\n" +
+			"  If installed via Homebrew: brew uninstall python\n" +
+			"  If installed via package: check /Applications or use the installer's uninstaller\n" +
+			"  Or manually remove from /usr/local/bin/"
+	case "linux":
+		return "To uninstall:\n" +
+			"  If installed via apt: sudo apt remove python3\n" +
+			"  If installed via yum: sudo yum remove python3\n" +
+			"  If installed via dnf: sudo dnf remove python3"
+	default:
+		return "Please use your system's package manager to uninstall Python"
+	}
+}
+
+// init registers the system provider on package load.
+func init() {
+	if err := migration.Register(NewProvider()); err != nil {
+		// Ignore registration errors (may already be registered)
+	}
+}

--- a/src/migrations/python/system/provider_test.go
+++ b/src/migrations/python/system/provider_test.go
@@ -1,0 +1,41 @@
+package system
+
+import (
+	"testing"
+
+	"github.com/dtvem/dtvem/src/internal/migration"
+)
+
+func TestProvider(t *testing.T) {
+	harness := &migration.ProviderTestHarness{
+		Provider:     NewProvider(),
+		ExpectedName: "system-python",
+		Runtime:      "python",
+	}
+	harness.RunAll(t)
+}
+
+func TestProvider_CanAutoUninstall(t *testing.T) {
+	p := NewProvider()
+
+	if p.CanAutoUninstall() {
+		t.Error("CanAutoUninstall() = true, want false")
+	}
+}
+
+func TestProvider_UninstallCommand(t *testing.T) {
+	p := NewProvider()
+
+	if cmd := p.UninstallCommand("3.11.0"); cmd != "" {
+		t.Errorf("UninstallCommand() = %q, want empty string", cmd)
+	}
+}
+
+func TestProvider_ManualInstructions(t *testing.T) {
+	p := NewProvider()
+
+	instructions := p.ManualInstructions()
+	if instructions == "" {
+		t.Error("ManualInstructions() returned empty string")
+	}
+}

--- a/src/migrations/ruby/chruby/provider.go
+++ b/src/migrations/ruby/chruby/provider.go
@@ -1,0 +1,125 @@
+// Package chruby provides a migration provider for chruby.
+package chruby
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/dtvem/dtvem/src/internal/migration"
+)
+
+// Provider implements the migration.Provider interface for chruby.
+type Provider struct{}
+
+// NewProvider creates a new chruby migration provider.
+func NewProvider() *Provider {
+	return &Provider{}
+}
+
+// Name returns the identifier for this version manager.
+func (p *Provider) Name() string {
+	return "chruby"
+}
+
+// DisplayName returns the human-readable name.
+func (p *Provider) DisplayName() string {
+	return "chruby"
+}
+
+// Runtime returns the runtime this provider manages.
+func (p *Provider) Runtime() string {
+	return "ruby"
+}
+
+// IsPresent checks if chruby is installed on the system.
+func (p *Provider) IsPresent() bool {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+
+	// chruby looks in /opt/rubies and ~/.rubies
+	chrubyDirs := []string{
+		"/opt/rubies",
+		filepath.Join(home, ".rubies"),
+	}
+
+	for _, chrubyDir := range chrubyDirs {
+		if _, err := os.Stat(chrubyDir); err == nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+// DetectVersions finds all versions installed for chruby.
+func (p *Provider) DetectVersions() ([]migration.DetectedVersion, error) {
+	detected := make([]migration.DetectedVersion, 0)
+	home, err := os.UserHomeDir()
+	if err != nil {
+		// If we can't get home dir, just return empty list (chruby won't be found anyway)
+		return detected, nil //nolint:nilerr // Expected: no home dir means no chruby
+	}
+
+	// chruby uses ruby-X.Y.Z format for directory names
+	versionRegex := regexp.MustCompile(`^ruby-(\d+\.\d+\.\d+)`)
+
+	// chruby looks in /opt/rubies and ~/.rubies
+	chrubyDirs := []string{
+		"/opt/rubies",
+		filepath.Join(home, ".rubies"),
+	}
+
+	for _, chrubyDir := range chrubyDirs {
+		if entries, err := os.ReadDir(chrubyDir); err == nil {
+			for _, entry := range entries {
+				if entry.IsDir() {
+					matches := versionRegex.FindStringSubmatch(entry.Name())
+					if len(matches) >= 2 {
+						versionDir := filepath.Join(chrubyDir, entry.Name())
+						rubyPath := filepath.Join(versionDir, "bin", "ruby")
+
+						if _, err := os.Stat(rubyPath); err == nil {
+							detected = append(detected, migration.DetectedVersion{
+								Version:   matches[1],
+								Path:      rubyPath,
+								Source:    "chruby",
+								Validated: false,
+							})
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return detected, nil
+}
+
+// CanAutoUninstall returns false because chruby doesn't have a built-in uninstall command.
+func (p *Provider) CanAutoUninstall() bool {
+	return false
+}
+
+// UninstallCommand returns an empty string because chruby doesn't have automatic uninstall.
+func (p *Provider) UninstallCommand(version string) string {
+	return ""
+}
+
+// ManualInstructions returns instructions for manual removal.
+func (p *Provider) ManualInstructions() string {
+	return "To manually remove a chruby-installed Ruby version:\n" +
+		"  1. Delete the version directory from ~/.rubies/ or /opt/rubies/\n" +
+		"  2. For example: rm -rf ~/.rubies/ruby-<version>\n" +
+		"Note: If using ruby-install, you may want to keep track of installed versions"
+}
+
+// init registers the chruby provider on package load.
+func init() {
+	if err := migration.Register(NewProvider()); err != nil {
+		panic(fmt.Sprintf("failed to register chruby migration provider: %v", err))
+	}
+}

--- a/src/migrations/ruby/chruby/provider_test.go
+++ b/src/migrations/ruby/chruby/provider_test.go
@@ -1,0 +1,57 @@
+package chruby
+
+import (
+	"testing"
+
+	"github.com/dtvem/dtvem/src/internal/migration"
+)
+
+func TestProvider(t *testing.T) {
+	harness := &migration.ProviderTestHarness{
+		Provider:     NewProvider(),
+		ExpectedName: "chruby",
+		Runtime:      "ruby",
+	}
+	harness.RunAll(t)
+}
+
+func TestProvider_CanAutoUninstall(t *testing.T) {
+	p := NewProvider()
+
+	// chruby doesn't support automatic uninstall
+	if p.CanAutoUninstall() {
+		t.Error("CanAutoUninstall() = true, want false")
+	}
+}
+
+func TestProvider_UninstallCommand(t *testing.T) {
+	p := NewProvider()
+
+	// chruby doesn't have an uninstall command
+	if cmd := p.UninstallCommand("3.3.0"); cmd != "" {
+		t.Errorf("UninstallCommand() = %q, want empty string", cmd)
+	}
+}
+
+func TestProvider_ManualInstructions(t *testing.T) {
+	p := NewProvider()
+
+	instructions := p.ManualInstructions()
+	if instructions == "" {
+		t.Error("ManualInstructions() returned empty string")
+	}
+
+	// Check that instructions mention removing directories
+	if !containsSubstring(instructions, "rubies") {
+		t.Error("ManualInstructions() should mention rubies directory")
+	}
+}
+
+func containsSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/src/migrations/ruby/rbenv/provider.go
+++ b/src/migrations/ruby/rbenv/provider.go
@@ -1,0 +1,106 @@
+// Package rbenv provides a migration provider for rbenv.
+package rbenv
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/dtvem/dtvem/src/internal/migration"
+)
+
+// Provider implements the migration.Provider interface for rbenv.
+type Provider struct{}
+
+// NewProvider creates a new rbenv migration provider.
+func NewProvider() *Provider {
+	return &Provider{}
+}
+
+// Name returns the identifier for this version manager.
+func (p *Provider) Name() string {
+	return "rbenv"
+}
+
+// DisplayName returns the human-readable name.
+func (p *Provider) DisplayName() string {
+	return "rbenv"
+}
+
+// Runtime returns the runtime this provider manages.
+func (p *Provider) Runtime() string {
+	return "ruby"
+}
+
+// IsPresent checks if rbenv is installed on the system.
+func (p *Provider) IsPresent() bool {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+
+	rbenvDir := filepath.Join(home, ".rbenv", "versions")
+	if _, err := os.Stat(rbenvDir); err == nil {
+		return true
+	}
+
+	return false
+}
+
+// DetectVersions finds all versions installed by rbenv.
+func (p *Provider) DetectVersions() ([]migration.DetectedVersion, error) {
+	detected := make([]migration.DetectedVersion, 0)
+	home, err := os.UserHomeDir()
+	if err != nil {
+		// If we can't get home dir, just return empty list (rbenv won't be found anyway)
+		return detected, nil //nolint:nilerr // Expected: no home dir means no rbenv
+	}
+
+	versionRegex := regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+
+	rbenvDir := filepath.Join(home, ".rbenv", "versions")
+	if entries, err := os.ReadDir(rbenvDir); err == nil {
+		for _, entry := range entries {
+			if entry.IsDir() && versionRegex.MatchString(entry.Name()) {
+				versionDir := filepath.Join(rbenvDir, entry.Name())
+				rubyPath := filepath.Join(versionDir, "bin", "ruby")
+
+				if _, err := os.Stat(rubyPath); err == nil {
+					detected = append(detected, migration.DetectedVersion{
+						Version:   entry.Name(),
+						Path:      rubyPath,
+						Source:    "rbenv",
+						Validated: false,
+					})
+				}
+			}
+		}
+	}
+
+	return detected, nil
+}
+
+// CanAutoUninstall returns true because rbenv supports automatic uninstall.
+func (p *Provider) CanAutoUninstall() bool {
+	return true
+}
+
+// UninstallCommand returns the command to uninstall a specific version.
+func (p *Provider) UninstallCommand(version string) string {
+	return fmt.Sprintf("rbenv uninstall %s", version)
+}
+
+// ManualInstructions returns instructions for manual removal.
+func (p *Provider) ManualInstructions() string {
+	return "To manually remove an rbenv-installed Ruby version:\n" +
+		"  1. Run: rbenv uninstall <version>\n" +
+		"  2. Or manually delete the version directory from ~/.rbenv/versions/"
+}
+
+// init registers the rbenv provider on package load.
+func init() {
+	if err := migration.Register(NewProvider()); err != nil {
+		panic(fmt.Sprintf("failed to register rbenv migration provider: %v", err))
+	}
+}

--- a/src/migrations/ruby/rbenv/provider_test.go
+++ b/src/migrations/ruby/rbenv/provider_test.go
@@ -1,0 +1,37 @@
+package rbenv
+
+import (
+	"testing"
+
+	"github.com/dtvem/dtvem/src/internal/migration"
+)
+
+func TestProvider(t *testing.T) {
+	harness := &migration.ProviderTestHarness{
+		Provider:     NewProvider(),
+		ExpectedName: "rbenv",
+		Runtime:      "ruby",
+	}
+	harness.RunAll(t)
+}
+
+func TestProvider_UninstallCommand(t *testing.T) {
+	p := NewProvider()
+
+	tests := []struct {
+		version  string
+		expected string
+	}{
+		{version: "3.3.0", expected: "rbenv uninstall 3.3.0"},
+		{version: "3.2.2", expected: "rbenv uninstall 3.2.2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			result := p.UninstallCommand(tt.version)
+			if result != tt.expected {
+				t.Errorf("UninstallCommand(%q) = %q, want %q", tt.version, result, tt.expected)
+			}
+		})
+	}
+}

--- a/src/migrations/ruby/rvm/provider.go
+++ b/src/migrations/ruby/rvm/provider.go
@@ -1,0 +1,110 @@
+// Package rvm provides a migration provider for Ruby Version Manager (rvm).
+package rvm
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/dtvem/dtvem/src/internal/migration"
+)
+
+// Provider implements the migration.Provider interface for rvm.
+type Provider struct{}
+
+// NewProvider creates a new rvm migration provider.
+func NewProvider() *Provider {
+	return &Provider{}
+}
+
+// Name returns the identifier for this version manager.
+func (p *Provider) Name() string {
+	return "rvm"
+}
+
+// DisplayName returns the human-readable name.
+func (p *Provider) DisplayName() string {
+	return "Ruby Version Manager (rvm)"
+}
+
+// Runtime returns the runtime this provider manages.
+func (p *Provider) Runtime() string {
+	return "ruby"
+}
+
+// IsPresent checks if rvm is installed on the system.
+func (p *Provider) IsPresent() bool {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+
+	rvmDir := filepath.Join(home, ".rvm", "rubies")
+	if _, err := os.Stat(rvmDir); err == nil {
+		return true
+	}
+
+	return false
+}
+
+// DetectVersions finds all versions installed by rvm.
+func (p *Provider) DetectVersions() ([]migration.DetectedVersion, error) {
+	detected := make([]migration.DetectedVersion, 0)
+	home, err := os.UserHomeDir()
+	if err != nil {
+		// If we can't get home dir, just return empty list (rvm won't be found anyway)
+		return detected, nil //nolint:nilerr // Expected: no home dir means no rvm
+	}
+
+	// rvm uses ruby-X.Y.Z format for directory names
+	versionRegex := regexp.MustCompile(`^ruby-(\d+\.\d+\.\d+)`)
+
+	rvmDir := filepath.Join(home, ".rvm", "rubies")
+	if entries, err := os.ReadDir(rvmDir); err == nil {
+		for _, entry := range entries {
+			if entry.IsDir() {
+				matches := versionRegex.FindStringSubmatch(entry.Name())
+				if len(matches) >= 2 {
+					versionDir := filepath.Join(rvmDir, entry.Name())
+					rubyPath := filepath.Join(versionDir, "bin", "ruby")
+
+					if _, err := os.Stat(rubyPath); err == nil {
+						detected = append(detected, migration.DetectedVersion{
+							Version:   matches[1],
+							Path:      rubyPath,
+							Source:    "rvm",
+							Validated: false,
+						})
+					}
+				}
+			}
+		}
+	}
+
+	return detected, nil
+}
+
+// CanAutoUninstall returns true because rvm supports automatic uninstall.
+func (p *Provider) CanAutoUninstall() bool {
+	return true
+}
+
+// UninstallCommand returns the command to uninstall a specific version.
+func (p *Provider) UninstallCommand(version string) string {
+	return fmt.Sprintf("rvm remove ruby-%s", version)
+}
+
+// ManualInstructions returns instructions for manual removal.
+func (p *Provider) ManualInstructions() string {
+	return "To manually remove an rvm-installed Ruby version:\n" +
+		"  1. Run: rvm remove ruby-<version>\n" +
+		"  2. Or manually delete the version directory from ~/.rvm/rubies/"
+}
+
+// init registers the rvm provider on package load.
+func init() {
+	if err := migration.Register(NewProvider()); err != nil {
+		panic(fmt.Sprintf("failed to register rvm migration provider: %v", err))
+	}
+}

--- a/src/migrations/ruby/rvm/provider_test.go
+++ b/src/migrations/ruby/rvm/provider_test.go
@@ -1,0 +1,37 @@
+package rvm
+
+import (
+	"testing"
+
+	"github.com/dtvem/dtvem/src/internal/migration"
+)
+
+func TestProvider(t *testing.T) {
+	harness := &migration.ProviderTestHarness{
+		Provider:     NewProvider(),
+		ExpectedName: "rvm",
+		Runtime:      "ruby",
+	}
+	harness.RunAll(t)
+}
+
+func TestProvider_UninstallCommand(t *testing.T) {
+	p := NewProvider()
+
+	tests := []struct {
+		version  string
+		expected string
+	}{
+		{version: "3.3.0", expected: "rvm remove ruby-3.3.0"},
+		{version: "3.2.2", expected: "rvm remove ruby-3.2.2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			result := p.UninstallCommand(tt.version)
+			if result != tt.expected {
+				t.Errorf("UninstallCommand(%q) = %q, want %q", tt.version, result, tt.expected)
+			}
+		})
+	}
+}

--- a/src/migrations/ruby/system/provider.go
+++ b/src/migrations/ruby/system/provider.go
@@ -1,0 +1,121 @@
+// Package system provides a migration provider for system-installed Ruby.
+package system
+
+import (
+	"os/exec"
+	"regexp"
+	goruntime "runtime"
+	"strings"
+
+	"github.com/dtvem/dtvem/src/internal/migration"
+	"github.com/dtvem/dtvem/src/internal/path"
+)
+
+// Provider implements the migration.Provider interface for system-installed Ruby.
+type Provider struct{}
+
+// NewProvider creates a new system Ruby migration provider.
+func NewProvider() *Provider {
+	return &Provider{}
+}
+
+// Name returns the identifier for this provider.
+func (p *Provider) Name() string {
+	return "system-ruby"
+}
+
+// DisplayName returns the human-readable name.
+func (p *Provider) DisplayName() string {
+	return "System Ruby"
+}
+
+// Runtime returns the runtime this provider manages.
+func (p *Provider) Runtime() string {
+	return "ruby"
+}
+
+// IsPresent checks if a system-installed Ruby exists in PATH.
+func (p *Provider) IsPresent() bool {
+	return path.LookPathExcludingShims("ruby") != ""
+}
+
+// DetectVersions finds system-installed Ruby in PATH.
+func (p *Provider) DetectVersions() ([]migration.DetectedVersion, error) {
+	detected := make([]migration.DetectedVersion, 0)
+
+	rubyPath := path.LookPathExcludingShims("ruby")
+	if rubyPath == "" {
+		return detected, nil
+	}
+
+	version := p.getVersion(rubyPath)
+	if version != "" {
+		detected = append(detected, migration.DetectedVersion{
+			Version:   version,
+			Path:      rubyPath,
+			Source:    "system",
+			Validated: true,
+		})
+	}
+
+	return detected, nil
+}
+
+// getVersion runs ruby --version and extracts the version number.
+func (p *Provider) getVersion(execPath string) string {
+	cmd := exec.Command(execPath, "--version")
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+
+	version := strings.TrimSpace(string(output))
+	re := regexp.MustCompile(`ruby\s+(\d+\.\d+\.\d+)`)
+	matches := re.FindStringSubmatch(version)
+	if len(matches) >= 2 {
+		return matches[1]
+	}
+
+	return ""
+}
+
+// CanAutoUninstall returns false because system installs require manual removal.
+func (p *Provider) CanAutoUninstall() bool {
+	return false
+}
+
+// UninstallCommand returns an empty string because system installs need manual removal.
+func (p *Provider) UninstallCommand(version string) string {
+	return ""
+}
+
+// ManualInstructions returns OS-specific uninstall instructions.
+func (p *Provider) ManualInstructions() string {
+	switch goruntime.GOOS {
+	case "windows":
+		return "To uninstall:\n" +
+			"  1. Open Settings \u2192 Apps \u2192 Installed apps\n" +
+			"  2. Search for Ruby\n" +
+			"  3. Click Uninstall\n" +
+			"  Or use PowerShell to find and run the uninstaller"
+	case "darwin":
+		return "To uninstall:\n" +
+			"  If installed via Homebrew: brew uninstall ruby\n" +
+			"  If installed via package: check /Applications or use the installer's uninstaller\n" +
+			"  Or manually remove from /usr/local/bin/"
+	case "linux":
+		return "To uninstall:\n" +
+			"  If installed via apt: sudo apt remove ruby\n" +
+			"  If installed via yum: sudo yum remove ruby\n" +
+			"  If installed via dnf: sudo dnf remove ruby"
+	default:
+		return "Please use your system's package manager to uninstall Ruby"
+	}
+}
+
+// init registers the system provider on package load.
+func init() {
+	if err := migration.Register(NewProvider()); err != nil {
+		// Ignore registration errors (may already be registered)
+	}
+}

--- a/src/migrations/ruby/system/provider_test.go
+++ b/src/migrations/ruby/system/provider_test.go
@@ -1,0 +1,41 @@
+package system
+
+import (
+	"testing"
+
+	"github.com/dtvem/dtvem/src/internal/migration"
+)
+
+func TestProvider(t *testing.T) {
+	harness := &migration.ProviderTestHarness{
+		Provider:     NewProvider(),
+		ExpectedName: "system-ruby",
+		Runtime:      "ruby",
+	}
+	harness.RunAll(t)
+}
+
+func TestProvider_CanAutoUninstall(t *testing.T) {
+	p := NewProvider()
+
+	if p.CanAutoUninstall() {
+		t.Error("CanAutoUninstall() = true, want false")
+	}
+}
+
+func TestProvider_UninstallCommand(t *testing.T) {
+	p := NewProvider()
+
+	if cmd := p.UninstallCommand("3.3.0"); cmd != "" {
+		t.Errorf("UninstallCommand() = %q, want empty string", cmd)
+	}
+}
+
+func TestProvider_ManualInstructions(t *testing.T) {
+	p := NewProvider()
+
+	instructions := p.ManualInstructions()
+	if instructions == "" {
+		t.Error("ManualInstructions() returned empty string")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #128

- Creates a plugin-style architecture for migration providers following the same pattern as runtime providers
- Adds `internal/migration` package with Provider interface and global registry
- Implements 10 migration providers organized by runtime:
  - **Node.js**: nvm (supports nvm-windows), fnm, system
  - **Python**: pyenv, system
  - **Ruby**: rbenv, rvm, chruby, system
- Updates `migrate.go` to use the new provider system
- Removes deprecated `find*Versions()` functions from runtime providers
- Includes test harness and comprehensive tests for all providers

## Test plan

- [x] All existing tests pass (`npm run check`)
- [x] New migration provider tests pass
- [x] Linter passes without errors