### PR TITLE
feat(init): add --yes flag to skip confirmation prompts

### DIFF
--- a/src/cmd/init.go
+++ b/src/cmd/init.go
@@ -7,6 +7,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var initYes bool
+
 var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize dtvem (setup directories and PATH)",
@@ -38,7 +40,7 @@ Example:
 		// Setup PATH - AddToPath handles checking position and moving if needed
 		shimsDir := path.ShimsDir()
 
-		if err := path.AddToPath(shimsDir); err != nil {
+		if err := path.AddToPath(shimsDir, initYes); err != nil {
 			ui.Error("Failed to configure PATH: %v", err)
 			ui.Info("You can manually add %s to your PATH", shimsDir)
 			return
@@ -53,5 +55,6 @@ Example:
 }
 
 func init() {
+	initCmd.Flags().BoolVarP(&initYes, "yes", "y", false, "Skip confirmation prompts")
 	rootCmd.AddCommand(initCmd)
 }

--- a/src/internal/path/path_unix.go
+++ b/src/internal/path/path_unix.go
@@ -52,8 +52,9 @@ func GetShellConfigFile(shell string) string {
 	}
 }
 
-// AddToPath adds the shims directory to the user's PATH by modifying their shell config
-func AddToPath(shimsDir string) error {
+// AddToPath adds the shims directory to the user's PATH by modifying their shell config.
+// If skipConfirmation is true, the function will proceed without prompting the user.
+func AddToPath(shimsDir string, skipConfirmation bool) error {
 	shell := DetectShell()
 	if shell == "unknown" {
 		return fmt.Errorf("could not detect shell - please add %s to your PATH manually", shimsDir)
@@ -85,22 +86,24 @@ func AddToPath(shimsDir string) error {
 		exportLine = fmt.Sprintf("\n# Added by dtvem\nexport PATH=\"%s:$PATH\"\n", shimsDir)
 	}
 
-	// Prompt user for confirmation
-	ui.Header("PATH Setup Required")
-	ui.Info("dtvem needs to add the shims directory to your PATH")
-	ui.Info("Shell: %s", ui.Highlight(shell))
-	ui.Info("Config file: %s", ui.Highlight(configFile))
-	ui.Info("Will append: %s", ui.Highlight(strings.TrimSpace(exportLine)))
-	fmt.Printf("\nProceed? [Y/n]: ")
+	// Prompt user for confirmation (unless skipConfirmation is true)
+	if !skipConfirmation {
+		ui.Header("PATH Setup Required")
+		ui.Info("dtvem needs to add the shims directory to your PATH")
+		ui.Info("Shell: %s", ui.Highlight(shell))
+		ui.Info("Config file: %s", ui.Highlight(configFile))
+		ui.Info("Will append: %s", ui.Highlight(strings.TrimSpace(exportLine)))
+		fmt.Printf("\nProceed? [Y/n]: ")
 
-	var response string
-	_, _ = fmt.Scanln(&response)
-	response = strings.ToLower(strings.TrimSpace(response))
+		var response string
+		_, _ = fmt.Scanln(&response)
+		response = strings.ToLower(strings.TrimSpace(response))
 
-	if response != "" && response != constants.ResponseY && response != constants.ResponseYes {
-		ui.Warning("PATH not modified. Please add this manually to your %s:", configFile)
-		ui.Info("%s", strings.TrimSpace(exportLine))
-		return nil
+		if response != "" && response != constants.ResponseY && response != constants.ResponseYes {
+			ui.Warning("PATH not modified. Please add this manually to your %s:", configFile)
+			ui.Info("%s", strings.TrimSpace(exportLine))
+			return nil
+		}
 	}
 
 	// Ensure the directory exists for fish config


### PR DESCRIPTION
## Summary
- Add `-y`/`--yes` flag to the `init` command to skip interactive confirmation prompts
- Allows non-interactive usage in CI environments where integration tests call `dtvem init --yes`

## Changes
- `src/cmd/init.go`: Add `initYes` flag variable and register with cobra
- `src/internal/path/path_unix.go`: Update `AddToPath` to accept `skipConfirmation` parameter, skip shell config modification prompt when set
- `src/internal/path/path_windows.go`: Update `AddToPath` and `promptForElevation` to accept skip parameter, skip elevation prompt when set

## Test plan
- [ ] Run `npm run check` (format, lint, test)
- [ ] Verify `dtvem init --yes` works without prompts
- [ ] Integration tests should no longer hang on init step

Fixes #132