### PR TITLE
feat(current): add --yes flag to skip install prompts

### DIFF
--- a/.github/workflows/integration-test-node.yml
+++ b/.github/workflows/integration-test-node.yml
@@ -131,7 +131,7 @@ jobs:
       - name: "Verify global version via current"
         run: |
           cd "$TEST_WORKSPACE"
-          CURRENT=$(./dtvem${{ matrix.ext }} current node)
+          CURRENT=$(./dtvem${{ matrix.ext }} current node --no-install)
           echo "Current node version: $CURRENT"
           if [[ "$CURRENT" != *"${{ inputs.version1 || '20.18.0' }}"* ]]; then
             echo "ERROR: Expected ${{ inputs.version1 || '20.18.0' }} but got $CURRENT"
@@ -173,7 +173,7 @@ jobs:
           mkdir -p test-project
           cd test-project
           ../dtvem${{ matrix.ext }} local node ${{ inputs.version1 || '20.18.0' }}
-          CURRENT=$(../dtvem${{ matrix.ext }} current node)
+          CURRENT=$(../dtvem${{ matrix.ext }} current node --no-install)
           echo "Current node version in test-project: $CURRENT"
           if [[ "$CURRENT" != *"${{ inputs.version1 || '20.18.0' }}"* ]]; then
             echo "ERROR: Local override failed. Expected ${{ inputs.version1 || '20.18.0' }} but got $CURRENT"

--- a/.github/workflows/integration-test-python.yml
+++ b/.github/workflows/integration-test-python.yml
@@ -131,7 +131,7 @@ jobs:
       - name: "Verify global version via current"
         run: |
           cd "$TEST_WORKSPACE"
-          CURRENT=$(./dtvem${{ matrix.ext }} current python)
+          CURRENT=$(./dtvem${{ matrix.ext }} current python --no-install)
           echo "Current python version: $CURRENT"
           if [[ "$CURRENT" != *"${{ inputs.version1 || '3.11.9' }}"* ]]; then
             echo "ERROR: Expected ${{ inputs.version1 || '3.11.9' }} but got $CURRENT"
@@ -173,7 +173,7 @@ jobs:
           mkdir -p test-project
           cd test-project
           ../dtvem${{ matrix.ext }} local python ${{ inputs.version1 || '3.11.9' }}
-          CURRENT=$(../dtvem${{ matrix.ext }} current python)
+          CURRENT=$(../dtvem${{ matrix.ext }} current python --no-install)
           echo "Current python version in test-project: $CURRENT"
           if [[ "$CURRENT" != *"${{ inputs.version1 || '3.11.9' }}"* ]]; then
             echo "ERROR: Local override failed. Expected ${{ inputs.version1 || '3.11.9' }} but got $CURRENT"

--- a/.github/workflows/integration-test-ruby.yml
+++ b/.github/workflows/integration-test-ruby.yml
@@ -131,7 +131,7 @@ jobs:
       - name: "Verify global version via current"
         run: |
           cd "$TEST_WORKSPACE"
-          CURRENT=$(./dtvem${{ matrix.ext }} current ruby)
+          CURRENT=$(./dtvem${{ matrix.ext }} current ruby --no-install)
           echo "Current ruby version: $CURRENT"
           if [[ "$CURRENT" != *"${{ inputs.version1 || '3.3.6' }}"* ]]; then
             echo "ERROR: Expected ${{ inputs.version1 || '3.3.6' }} but got $CURRENT"
@@ -173,7 +173,7 @@ jobs:
           mkdir -p test-project
           cd test-project
           ../dtvem${{ matrix.ext }} local ruby ${{ inputs.version1 || '3.3.6' }}
-          CURRENT=$(../dtvem${{ matrix.ext }} current ruby)
+          CURRENT=$(../dtvem${{ matrix.ext }} current ruby --no-install)
           echo "Current ruby version in test-project: $CURRENT"
           if [[ "$CURRENT" != *"${{ inputs.version1 || '3.3.6' }}"* ]]; then
             echo "ERROR: Local override failed. Expected ${{ inputs.version1 || '3.3.6' }} but got $CURRENT"


### PR DESCRIPTION
## Summary

- Add `--yes`/`-y` flag to automatically install missing versions without prompting
- Add `--no-install`/`-n` flag to skip install prompts entirely
- Update integration tests to use `--no-install` to prevent CI hangs

## Problem

The `current` command prompts to install missing versions interactively, which causes issues in CI environments where stdin is not available - either hanging or auto-accepting due to empty stdin.

## Solution

Added two flags to control install behavior:
- `--yes` / `-y`: Auto-accept install prompts
- `--no-install` / `-n`: Skip prompts entirely (recommended for CI)

## Test plan

- [x] All existing tests pass (230+)
- [x] Linting passes (0 issues)
- [x] Updated integration tests to use `--no-install`

Fixes #136