### PR TITLE
test(ci): enable Node.js Ubuntu migration integration tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -36,17 +36,19 @@ jobs:
       version2: '3.4.1'
 
   # ==========================================================================
-  # Migration Tests - DISABLED until installation issues are resolved
-  # See: https://github.com/dtvem/dtvem/issues (create tracking issue)
+  # Migration Tests
   # ==========================================================================
-  # migrate-node-ubuntu-system:
-  #   name: Migrate Node.js from System (Ubuntu)
-  #   uses: ./.github/workflows/integration-test-migrate-node-ubuntu-system.yml
-  #
-  # migrate-node-ubuntu-nvm:
-  #   name: Migrate Node.js from nvm (Ubuntu)
-  #   uses: ./.github/workflows/integration-test-migrate-node-ubuntu-nvm.yml
-  #
+  migrate-node-ubuntu-system:
+    name: Migrate Node.js from System (Ubuntu)
+    uses: ./.github/workflows/integration-test-migrate-node-ubuntu-system.yml
+
+  migrate-node-ubuntu-nvm:
+    name: Migrate Node.js from nvm (Ubuntu)
+    uses: ./.github/workflows/integration-test-migrate-node-ubuntu-nvm.yml
+
+  # --------------------------------------------------------------------------
+  # Remaining migration tests - re-enable incrementally
+  # --------------------------------------------------------------------------
   # migrate-node-macos-system:
   #   name: Migrate Node.js from System (macOS)
   #   uses: ./.github/workflows/integration-test-migrate-node-macos-system.yml


### PR DESCRIPTION
## Summary

- Re-enable the Node.js migration integration tests for Ubuntu
- Includes both `system` and `nvm` migration source tests
- First step in incrementally re-enabling all migration integration tests

## Test plan

- [ ] Verify `migrate-node-ubuntu-system` workflow passes
- [ ] Verify `migrate-node-ubuntu-nvm` workflow passes