### PR TITLE
fix(ci): use pre-installed Node.js for macOS/Windows migration tests

### DIFF
--- a/.github/workflows/integration-test-migrate-node-macos-system.yml
+++ b/.github/workflows/integration-test-migrate-node-macos-system.yml
@@ -34,12 +34,13 @@ jobs:
           echo "$HOME/.dtvem/shims" >> $GITHUB_PATH
           echo "$HOME/.dtvem/bin" >> $GITHUB_PATH
 
-      - name: "Install Node.js 18.x via Homebrew"
+      - name: "Verify pre-installed Node.js"
         run: |
-          brew install node@18
-          brew link --overwrite node@18
           echo "System Node.js installed at: $(which node)"
           node --version
+          # Capture the version for later verification
+          NODE_VERSION=$(node --version | sed 's/v//')
+          echo "NODE_VERSION=$NODE_VERSION" >> $GITHUB_ENV
 
       - name: "Migrate system Node.js to dtvem"
         run: |
@@ -51,16 +52,17 @@ jobs:
 
       - name: "Verify migrated version"
         run: |
-          ./dist/dtvem list node | grep -E "18\." || (echo "ERROR: Expected Node.js 18.x to be migrated" && exit 1)
-          echo "SUCCESS: Node.js 18.x was migrated from system"
+          # Check that we have the same version that was pre-installed
+          ./dist/dtvem list node | grep -F "$NODE_VERSION" || (echo "ERROR: Expected Node.js $NODE_VERSION to be migrated" && exit 1)
+          echo "SUCCESS: Node.js $NODE_VERSION was migrated from system"
 
       - name: Generate summary
         if: always()
         run: |
           echo "## Node.js Migration from System (macOS)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Source:** Homebrew" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** 18.x" >> $GITHUB_STEP_SUMMARY
+          echo "**Source:** Pre-installed system Node.js" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** $NODE_VERSION" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Installed Versions" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/integration-test-migrate-node-windows-system.yml
+++ b/.github/workflows/integration-test-migrate-node-windows-system.yml
@@ -37,21 +37,14 @@ jobs:
           "$env:USERPROFILE\.dtvem\shims" | Out-File -FilePath $env:GITHUB_PATH -Append
           "$env:USERPROFILE\.dtvem\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
 
-      - name: "Install Node.js 18.x via Chocolatey"
+      - name: "Verify pre-installed Node.js"
         shell: pwsh
         run: |
-          choco install nodejs-lts --version=18.20.4 -y
-          $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
           Write-Host "System Node.js installed at: $(where.exe node)"
-          node --version
-
-      - name: "Add Chocolatey Node.js to PATH"
-        shell: pwsh
-        run: |
-          $nodePath = "C:\Program Files\nodejs"
-          if (Test-Path $nodePath) {
-            $nodePath | Out-File -FilePath $env:GITHUB_PATH -Append
-          }
+          $version = (node --version) -replace '^v', ''
+          Write-Host "Node.js version: $version"
+          # Save version for later verification
+          "NODE_VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: "Migrate system Node.js to dtvem"
         shell: bash
@@ -65,8 +58,9 @@ jobs:
       - name: "Verify migrated version"
         shell: bash
         run: |
-          ./dist/dtvem.exe list node | grep -E "18\." || (echo "ERROR: Expected Node.js 18.x to be migrated" && exit 1)
-          echo "SUCCESS: Node.js 18.x was migrated from system"
+          # Check that we have the same version that was pre-installed
+          ./dist/dtvem.exe list node | grep -F "$NODE_VERSION" || (echo "ERROR: Expected Node.js $NODE_VERSION to be migrated" && exit 1)
+          echo "SUCCESS: Node.js $NODE_VERSION was migrated from system"
 
       - name: Generate summary
         if: always()
@@ -74,8 +68,8 @@ jobs:
         run: |
           echo "## Node.js Migration from System (Windows)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Source:** Chocolatey" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** 18.x" >> $GITHUB_STEP_SUMMARY
+          echo "**Source:** Pre-installed system Node.js" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** $NODE_VERSION" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Installed Versions" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -46,20 +46,20 @@ jobs:
     name: Migrate Node.js from nvm (Ubuntu)
     uses: ./.github/workflows/integration-test-migrate-node-ubuntu-nvm.yml
 
+  migrate-node-macos-system:
+    name: Migrate Node.js from System (macOS)
+    uses: ./.github/workflows/integration-test-migrate-node-macos-system.yml
+
+  migrate-node-windows-system:
+    name: Migrate Node.js from System (Windows)
+    uses: ./.github/workflows/integration-test-migrate-node-windows-system.yml
+
   # --------------------------------------------------------------------------
   # Remaining migration tests - re-enable incrementally
   # --------------------------------------------------------------------------
-  # migrate-node-macos-system:
-  #   name: Migrate Node.js from System (macOS)
-  #   uses: ./.github/workflows/integration-test-migrate-node-macos-system.yml
-  #
   # migrate-node-macos-fnm:
   #   name: Migrate Node.js from fnm (macOS)
   #   uses: ./.github/workflows/integration-test-migrate-node-macos-fnm.yml
-  #
-  # migrate-node-windows-system:
-  #   name: Migrate Node.js from System (Windows)
-  #   uses: ./.github/workflows/integration-test-migrate-node-windows-system.yml
   #
   # migrate-node-windows-nvm:
   #   name: Migrate Node.js from nvm-windows (Windows)


### PR DESCRIPTION
## Summary

- Use pre-installed Node.js on GitHub runners instead of installing via package managers
- macOS: Remove Homebrew `node@18` installation step
- Windows: Remove Chocolatey `nodejs-lts` installation step  
- Dynamically capture and verify the installed version
- Enable macOS and Windows system migration tests

Follow-up to #145, applying the same simplification to macOS and Windows.

## Test plan

- [ ] Verify `migrate-node-macos-system` workflow passes
- [ ] Verify `migrate-node-windows-system` workflow passes