### PR TITLE
feat(ci): add split integration test suites for targeted testing

### DIFF
--- a/.github/workflows/integration-test-migrations-node.yml
+++ b/.github/workflows/integration-test-migrations-node.yml
@@ -1,0 +1,36 @@
+name: Integration Tests - Node.js Migrations
+
+on:
+  workflow_dispatch:
+    # Manual trigger for testing Node.js migrations only
+
+permissions:
+  contents: read
+
+jobs:
+  # Ubuntu
+  migrate-node-ubuntu-system:
+    name: System (Ubuntu)
+    uses: ./.github/workflows/integration-test-migrate-node-ubuntu-system.yml
+
+  migrate-node-ubuntu-nvm:
+    name: nvm (Ubuntu)
+    uses: ./.github/workflows/integration-test-migrate-node-ubuntu-nvm.yml
+
+  # macOS
+  migrate-node-macos-system:
+    name: System (macOS)
+    uses: ./.github/workflows/integration-test-migrate-node-macos-system.yml
+
+  migrate-node-macos-fnm:
+    name: fnm (macOS)
+    uses: ./.github/workflows/integration-test-migrate-node-macos-fnm.yml
+
+  # Windows
+  migrate-node-windows-system:
+    name: System (Windows)
+    uses: ./.github/workflows/integration-test-migrate-node-windows-system.yml
+
+  migrate-node-windows-nvm:
+    name: nvm-windows (Windows)
+    uses: ./.github/workflows/integration-test-migrate-node-windows-nvm.yml

--- a/.github/workflows/integration-test-migrations-python.yml
+++ b/.github/workflows/integration-test-migrations-python.yml
@@ -1,0 +1,36 @@
+name: Integration Tests - Python Migrations
+
+on:
+  workflow_dispatch:
+    # Manual trigger for testing Python migrations only
+
+permissions:
+  contents: read
+
+jobs:
+  # Ubuntu
+  migrate-python-ubuntu-system:
+    name: System (Ubuntu)
+    uses: ./.github/workflows/integration-test-migrate-python-ubuntu-system.yml
+
+  migrate-python-ubuntu-pyenv:
+    name: pyenv (Ubuntu)
+    uses: ./.github/workflows/integration-test-migrate-python-ubuntu-pyenv.yml
+
+  # macOS
+  migrate-python-macos-system:
+    name: System (macOS)
+    uses: ./.github/workflows/integration-test-migrate-python-macos-system.yml
+
+  migrate-python-macos-pyenv:
+    name: pyenv (macOS)
+    uses: ./.github/workflows/integration-test-migrate-python-macos-pyenv.yml
+
+  # Windows
+  migrate-python-windows-system:
+    name: System (Windows)
+    uses: ./.github/workflows/integration-test-migrate-python-windows-system.yml
+
+  migrate-python-windows-pyenv:
+    name: pyenv-win (Windows)
+    uses: ./.github/workflows/integration-test-migrate-python-windows-pyenv.yml

--- a/.github/workflows/integration-test-migrations-ruby.yml
+++ b/.github/workflows/integration-test-migrations-ruby.yml
@@ -1,0 +1,36 @@
+name: Integration Tests - Ruby Migrations
+
+on:
+  workflow_dispatch:
+    # Manual trigger for testing Ruby migrations only
+
+permissions:
+  contents: read
+
+jobs:
+  # Ubuntu
+  migrate-ruby-ubuntu-system:
+    name: System (Ubuntu)
+    uses: ./.github/workflows/integration-test-migrate-ruby-ubuntu-system.yml
+
+  migrate-ruby-ubuntu-rbenv:
+    name: rbenv (Ubuntu)
+    uses: ./.github/workflows/integration-test-migrate-ruby-ubuntu-rbenv.yml
+
+  # macOS
+  migrate-ruby-macos-system:
+    name: System (macOS)
+    uses: ./.github/workflows/integration-test-migrate-ruby-macos-system.yml
+
+  migrate-ruby-macos-rbenv:
+    name: rbenv (macOS)
+    uses: ./.github/workflows/integration-test-migrate-ruby-macos-rbenv.yml
+
+  # Windows
+  migrate-ruby-windows-system:
+    name: System (Windows)
+    uses: ./.github/workflows/integration-test-migrate-ruby-windows-system.yml
+
+  migrate-ruby-windows-uru:
+    name: uru (Windows)
+    uses: ./.github/workflows/integration-test-migrate-ruby-windows-uru.yml

--- a/.github/workflows/integration-test-migrations.yml
+++ b/.github/workflows/integration-test-migrations.yml
@@ -1,0 +1,90 @@
+name: Integration Tests - All Migrations
+
+on:
+  workflow_dispatch:
+    # Manual trigger for testing all migrations without runtime tests
+
+permissions:
+  contents: read
+
+jobs:
+  # ==========================================================================
+  # Node.js Migrations
+  # ==========================================================================
+  migrate-node-ubuntu-system:
+    name: Node.js - System (Ubuntu)
+    uses: ./.github/workflows/integration-test-migrate-node-ubuntu-system.yml
+
+  migrate-node-ubuntu-nvm:
+    name: Node.js - nvm (Ubuntu)
+    uses: ./.github/workflows/integration-test-migrate-node-ubuntu-nvm.yml
+
+  migrate-node-macos-system:
+    name: Node.js - System (macOS)
+    uses: ./.github/workflows/integration-test-migrate-node-macos-system.yml
+
+  migrate-node-macos-fnm:
+    name: Node.js - fnm (macOS)
+    uses: ./.github/workflows/integration-test-migrate-node-macos-fnm.yml
+
+  migrate-node-windows-system:
+    name: Node.js - System (Windows)
+    uses: ./.github/workflows/integration-test-migrate-node-windows-system.yml
+
+  migrate-node-windows-nvm:
+    name: Node.js - nvm-windows (Windows)
+    uses: ./.github/workflows/integration-test-migrate-node-windows-nvm.yml
+
+  # ==========================================================================
+  # Python Migrations
+  # ==========================================================================
+  migrate-python-ubuntu-system:
+    name: Python - System (Ubuntu)
+    uses: ./.github/workflows/integration-test-migrate-python-ubuntu-system.yml
+
+  migrate-python-ubuntu-pyenv:
+    name: Python - pyenv (Ubuntu)
+    uses: ./.github/workflows/integration-test-migrate-python-ubuntu-pyenv.yml
+
+  migrate-python-macos-system:
+    name: Python - System (macOS)
+    uses: ./.github/workflows/integration-test-migrate-python-macos-system.yml
+
+  migrate-python-macos-pyenv:
+    name: Python - pyenv (macOS)
+    uses: ./.github/workflows/integration-test-migrate-python-macos-pyenv.yml
+
+  migrate-python-windows-system:
+    name: Python - System (Windows)
+    uses: ./.github/workflows/integration-test-migrate-python-windows-system.yml
+
+  migrate-python-windows-pyenv:
+    name: Python - pyenv-win (Windows)
+    uses: ./.github/workflows/integration-test-migrate-python-windows-pyenv.yml
+
+  # ==========================================================================
+  # Ruby Migrations
+  # ==========================================================================
+  migrate-ruby-ubuntu-system:
+    name: Ruby - System (Ubuntu)
+    uses: ./.github/workflows/integration-test-migrate-ruby-ubuntu-system.yml
+
+  migrate-ruby-ubuntu-rbenv:
+    name: Ruby - rbenv (Ubuntu)
+    uses: ./.github/workflows/integration-test-migrate-ruby-ubuntu-rbenv.yml
+
+  migrate-ruby-macos-system:
+    name: Ruby - System (macOS)
+    uses: ./.github/workflows/integration-test-migrate-ruby-macos-system.yml
+
+  migrate-ruby-macos-rbenv:
+    name: Ruby - rbenv (macOS)
+    uses: ./.github/workflows/integration-test-migrate-ruby-macos-rbenv.yml
+
+  migrate-ruby-windows-system:
+    name: Ruby - System (Windows)
+    uses: ./.github/workflows/integration-test-migrate-ruby-windows-system.yml
+
+  migrate-ruby-windows-uru:
+    name: Ruby - uru (Windows)
+    uses: ./.github/workflows/integration-test-migrate-ruby-windows-uru.yml

--- a/.github/workflows/integration-test-runtimes.yml
+++ b/.github/workflows/integration-test-runtimes.yml
@@ -1,0 +1,30 @@
+name: Integration Tests - Runtimes
+
+on:
+  workflow_dispatch:
+    # Manual trigger for testing runtime install/uninstall without migrations
+
+permissions:
+  contents: read
+
+jobs:
+  node:
+    name: Node.js
+    uses: ./.github/workflows/integration-test-node.yml
+    with:
+      version1: '20.18.0'
+      version2: '22.11.0'
+
+  python:
+    name: Python
+    uses: ./.github/workflows/integration-test-python.yml
+    with:
+      version1: '3.11.9'
+      version2: '3.12.7'
+
+  ruby:
+    name: Ruby
+    uses: ./.github/workflows/integration-test-ruby.yml
+    with:
+      version1: '3.3.6'
+      version2: '3.4.1'


### PR DESCRIPTION
## Summary

Add orchestrator workflows for running specific subsets of integration tests without running everything:

| Workflow | Purpose |
|----------|---------|
| `integration-test-runtimes.yml` | Runtime install/uninstall tests (node, python, ruby) |
| `integration-test-migrations.yml` | All 18 migration tests |
| `integration-test-migrations-node.yml` | Node.js migrations only (6 tests) |
| `integration-test-migrations-python.yml` | Python migrations only (6 tests) |
| `integration-test-migrations-ruby.yml` | Ruby migrations only (6 tests) |

All workflows are manual-trigger only (`workflow_dispatch`). The main `integration-test.yml` continues to run everything on the weekly schedule.

## Usage

From GitHub Actions UI: Actions > Select workflow > Run workflow

## Test plan

- [ ] Verify workflows appear in GitHub Actions UI
- [ ] Test manual trigger of `integration-test-runtimes.yml`
- [ ] Test manual trigger of `integration-test-migrations-node.yml`