### PR TITLE
fix(ci): select all versions in nvm migration test

### DIFF
--- a/.github/workflows/integration-test-migrate-node-ubuntu-nvm.yml
+++ b/.github/workflows/integration-test-migrate-node-ubuntu-nvm.yml
@@ -47,7 +47,8 @@ jobs:
       - name: "Migrate nvm Node.js to dtvem"
         run: |
           echo "=== Running migrate detection ==="
-          echo -e "1\n0\nn\n" | ./dist/dtvem migrate node || true
+          # Select "all" to migrate all detected versions (system + nvm)
+          echo -e "all\n0\nn\n" | ./dist/dtvem migrate node || true
           echo ""
           echo "=== Verifying migration ==="
           ./dist/dtvem list node


### PR DESCRIPTION
## Summary

Fix the nvm migration test that was failing because it selected the wrong version.

**Problem:**
- Test installs Node.js 20.18.0 via nvm
- Migration detects two versions: `[1] system` and `[2] nvm`
- Test input `1\n...` selected the system version, not the nvm version
- Verification failed looking for 20.18.0

**Solution:**
- Change selection from `1` to `all` to migrate both versions
- Verification still checks that 20.18.0 is among migrated versions

## Test plan

- [ ] Verify `migrate-node-ubuntu-nvm` workflow passes