### PR TITLE
fix(ci): fix fnm and nvm-windows migration tests

### DIFF
--- a/.github/workflows/integration-test-migrate-node-macos-fnm.yml
+++ b/.github/workflows/integration-test-migrate-node-macos-fnm.yml
@@ -51,7 +51,8 @@ jobs:
       - name: "Migrate fnm Node.js to dtvem"
         run: |
           echo "=== Running migrate detection ==="
-          echo -e "1\n0\nn\n" | ./dist/dtvem migrate node || true
+          # Select "all" to migrate all detected versions (system + fnm)
+          echo -e "all\n0\nn\n" | ./dist/dtvem migrate node || true
           echo ""
           echo "=== Verifying migration ==="
           ./dist/dtvem list node

--- a/.github/workflows/integration-test-migrate-node-windows-nvm.yml
+++ b/.github/workflows/integration-test-migrate-node-windows-nvm.yml
@@ -41,12 +41,17 @@ jobs:
         shell: pwsh
         run: |
           choco install nvm -y
-          $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+          # Add nvm to GITHUB_PATH for subsequent steps
+          $nvmHome = [System.Environment]::GetEnvironmentVariable("NVM_HOME", "Machine")
+          if (-not $nvmHome) { $nvmHome = "C:\ProgramData\nvm" }
+          $nvmSymlink = [System.Environment]::GetEnvironmentVariable("NVM_SYMLINK", "Machine")
+          if (-not $nvmSymlink) { $nvmSymlink = "C:\Program Files\nodejs" }
+          "$nvmHome" | Out-File -FilePath $env:GITHUB_PATH -Append
+          "$nvmSymlink" | Out-File -FilePath $env:GITHUB_PATH -Append
 
       - name: "Install Node.js 20.18.0 via nvm-windows"
         shell: pwsh
         run: |
-          $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
           nvm install 20.18.0
           nvm use 20.18.0
           Write-Host "nvm-windows Node.js version:"
@@ -56,7 +61,8 @@ jobs:
         shell: bash
         run: |
           echo "=== Running migrate detection ==="
-          echo -e "1\n0\nn\n" | ./dist/dtvem.exe migrate node || true
+          # Select "all" to migrate all detected versions (system + nvm)
+          echo -e "all\n0\nn\n" | ./dist/dtvem.exe migrate node || true
           echo ""
           echo "=== Verifying migration ==="
           ./dist/dtvem.exe list node


### PR DESCRIPTION
## Summary

Fix the remaining Node.js migration test failures:

**fnm (macOS):**
- Change selection from `1` to `all` - same issue as nvm (Ubuntu)
- System Node.js was being selected instead of fnm-installed version

**nvm-windows (Windows):**
- Add nvm directories to `GITHUB_PATH` for cross-step availability
- The PATH refresh wasn't working across PowerShell steps
- Change selection from `1` to `all`

## Test plan

- [ ] Verify `migrate-node-macos-fnm` workflow passes
- [ ] Verify `migrate-node-windows-nvm` workflow passes