### PR TITLE
fix(ci): select all versions in Python migration tests

### DIFF
--- a/.github/workflows/integration-test-migrate-python-macos-pyenv.yml
+++ b/.github/workflows/integration-test-migrate-python-macos-pyenv.yml
@@ -49,7 +49,8 @@ jobs:
       - name: "Migrate pyenv Python to dtvem"
         run: |
           echo "=== Running migrate detection ==="
-          echo -e "1\n0\nn\n" | ./dist/dtvem migrate python || true
+          # Select "all" to migrate all detected versions
+          echo -e "all\n0\nn\n" | ./dist/dtvem migrate python || true
           echo ""
           echo "=== Verifying migration ==="
           ./dist/dtvem list python

--- a/.github/workflows/integration-test-migrate-python-macos-system.yml
+++ b/.github/workflows/integration-test-migrate-python-macos-system.yml
@@ -44,7 +44,8 @@ jobs:
       - name: "Migrate system Python to dtvem"
         run: |
           echo "=== Running migrate detection ==="
-          echo -e "1\n0\n" | ./dist/dtvem migrate python || true
+          # Select "all" to migrate all detected versions
+          echo -e "all\n0\n" | ./dist/dtvem migrate python || true
           echo ""
           echo "=== Verifying migration ==="
           ./dist/dtvem list python

--- a/.github/workflows/integration-test-migrate-python-ubuntu-pyenv.yml
+++ b/.github/workflows/integration-test-migrate-python-ubuntu-pyenv.yml
@@ -58,7 +58,8 @@ jobs:
       - name: "Migrate pyenv Python to dtvem"
         run: |
           echo "=== Running migrate detection ==="
-          echo -e "1\n0\nn\n" | ./dist/dtvem migrate python || true
+          # Select "all" to migrate all detected versions
+          echo -e "all\n0\nn\n" | ./dist/dtvem migrate python || true
           echo ""
           echo "=== Verifying migration ==="
           ./dist/dtvem list python

--- a/.github/workflows/integration-test-migrate-python-ubuntu-system.yml
+++ b/.github/workflows/integration-test-migrate-python-ubuntu-system.yml
@@ -45,7 +45,8 @@ jobs:
       - name: "Migrate system Python to dtvem"
         run: |
           echo "=== Running migrate detection ==="
-          echo -e "1\n0\n" | ./dist/dtvem migrate python || true
+          # Select "all" to migrate all detected versions
+          echo -e "all\n0\n" | ./dist/dtvem migrate python || true
           echo ""
           echo "=== Verifying migration ==="
           ./dist/dtvem list python

--- a/.github/workflows/integration-test-migrate-python-windows-pyenv.yml
+++ b/.github/workflows/integration-test-migrate-python-windows-pyenv.yml
@@ -61,7 +61,8 @@ jobs:
         shell: bash
         run: |
           echo "=== Running migrate detection ==="
-          echo -e "1\n0\nn\n" | ./dist/dtvem.exe migrate python || true
+          # Select "all" to migrate all detected versions
+          echo -e "all\n0\nn\n" | ./dist/dtvem.exe migrate python || true
           echo ""
           echo "=== Verifying migration ==="
           ./dist/dtvem.exe list python

--- a/.github/workflows/integration-test-migrate-python-windows-system.yml
+++ b/.github/workflows/integration-test-migrate-python-windows-system.yml
@@ -58,7 +58,8 @@ jobs:
         shell: bash
         run: |
           echo "=== Running migrate detection ==="
-          echo -e "1\n0\n" | ./dist/dtvem.exe migrate python || true
+          # Select "all" to migrate all detected versions
+          echo -e "all\n0\n" | ./dist/dtvem.exe migrate python || true
           echo ""
           echo "=== Verifying migration ==="
           ./dist/dtvem.exe list python


### PR DESCRIPTION
## Summary
- Fixed version selection in all 6 Python migration test workflows
- Changed selection from "1" (which selected wrong version) to "all" to migrate all detected versions
- Same issue that was fixed for Node.js migration tests

## Test plan
- [ ] All 6 Python migration tests pass:
  - Ubuntu system
  - Ubuntu pyenv
  - macOS system
  - macOS pyenv
  - Windows system
  - Windows pyenv-win