### PR TITLE
fix(ci): use available Python versions in migration tests

### DIFF
--- a/.github/workflows/integration-test-migrate-python-macos-system.yml
+++ b/.github/workflows/integration-test-migrate-python-macos-system.yml
@@ -34,12 +34,19 @@ jobs:
           echo "$HOME/.dtvem/shims" >> $GITHUB_PATH
           echo "$HOME/.dtvem/bin" >> $GITHUB_PATH
 
-      - name: "Install Python 3.10 via Homebrew"
+      - name: "Set up Python 3.11.9 (available in python-build-standalone)"
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11.9'
+
+      - name: "Verify Python version"
+        id: detect-python
         run: |
-          brew install python@3.10
-          brew link --overwrite python@3.10
-          echo "System Python installed at: $(which python3.10)"
-          python3.10 --version
+          echo "System Python installed at: $(which python3)"
+          python3 --version
+          # Extract version for verification
+          VERSION=$(python3 --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          echo "PYTHON_VERSION=$VERSION" >> $GITHUB_OUTPUT
 
       - name: "Migrate system Python to dtvem"
         run: |
@@ -51,17 +58,24 @@ jobs:
           ./dist/dtvem list python
 
       - name: "Verify migrated version"
+        env:
+          EXPECTED_VERSION: ${{ steps.detect-python.outputs.PYTHON_VERSION }}
         run: |
-          ./dist/dtvem list python | grep -E "3\.10\." || (echo "ERROR: Expected Python 3.10.x to be migrated" && exit 1)
-          echo "SUCCESS: Python 3.10.x was migrated from system"
+          # Extract major.minor from detected version (e.g., "3.11" from "3.11.9")
+          MAJOR_MINOR=$(echo "$EXPECTED_VERSION" | cut -d. -f1,2)
+          echo "Looking for Python $MAJOR_MINOR.x"
+          ./dist/dtvem list python | grep -E "${MAJOR_MINOR}\." || (echo "ERROR: Expected Python ${MAJOR_MINOR}.x to be migrated" && exit 1)
+          echo "SUCCESS: Python ${MAJOR_MINOR}.x was migrated from system"
 
       - name: Generate summary
         if: always()
+        env:
+          EXPECTED_VERSION: ${{ steps.detect-python.outputs.PYTHON_VERSION }}
         run: |
           echo "## Python Migration from System (macOS)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Source:** Homebrew" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** 3.10.x" >> $GITHUB_STEP_SUMMARY
+          echo "**Source:** actions/setup-python" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** $EXPECTED_VERSION" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Installed Versions" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/integration-test-migrate-python-ubuntu-system.yml
+++ b/.github/workflows/integration-test-migrate-python-ubuntu-system.yml
@@ -34,13 +34,19 @@ jobs:
           echo "$HOME/.dtvem/shims" >> $GITHUB_PATH
           echo "$HOME/.dtvem/bin" >> $GITHUB_PATH
 
-      - name: "Install Python 3.10 via apt (deadsnakes PPA)"
+      - name: "Set up Python 3.11.9 (available in python-build-standalone)"
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11.9'
+
+      - name: "Verify Python version"
+        id: detect-python
         run: |
-          sudo add-apt-repository ppa:deadsnakes/ppa -y
-          sudo apt-get update
-          sudo apt-get install -y python3.10 python3.10-venv python3.10-dev
-          echo "System Python installed at: $(which python3.10)"
-          python3.10 --version
+          echo "System Python installed at: $(which python3)"
+          python3 --version
+          # Extract version for verification
+          VERSION=$(python3 --version | grep -oP '\d+\.\d+\.\d+')
+          echo "PYTHON_VERSION=$VERSION" >> $GITHUB_OUTPUT
 
       - name: "Migrate system Python to dtvem"
         run: |
@@ -52,17 +58,24 @@ jobs:
           ./dist/dtvem list python
 
       - name: "Verify migrated version"
+        env:
+          EXPECTED_VERSION: ${{ steps.detect-python.outputs.PYTHON_VERSION }}
         run: |
-          ./dist/dtvem list python | grep -E "3\.10\." || (echo "ERROR: Expected Python 3.10.x to be migrated" && exit 1)
-          echo "SUCCESS: Python 3.10.x was migrated from system"
+          # Extract major.minor from detected version (e.g., "3.11" from "3.11.9")
+          MAJOR_MINOR=$(echo "$EXPECTED_VERSION" | cut -d. -f1,2)
+          echo "Looking for Python $MAJOR_MINOR.x"
+          ./dist/dtvem list python | grep -E "${MAJOR_MINOR}\." || (echo "ERROR: Expected Python ${MAJOR_MINOR}.x to be migrated" && exit 1)
+          echo "SUCCESS: Python ${MAJOR_MINOR}.x was migrated from system"
 
       - name: Generate summary
         if: always()
+        env:
+          EXPECTED_VERSION: ${{ steps.detect-python.outputs.PYTHON_VERSION }}
         run: |
           echo "## Python Migration from System (Ubuntu)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Source:** apt (deadsnakes PPA)" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** 3.10.x" >> $GITHUB_STEP_SUMMARY
+          echo "**Source:** actions/setup-python" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** $EXPECTED_VERSION" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Installed Versions" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/integration-test-migrate-python-windows-pyenv.yml
+++ b/.github/workflows/integration-test-migrate-python-windows-pyenv.yml
@@ -47,15 +47,30 @@ jobs:
           "$env:USERPROFILE\.pyenv\pyenv-win\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
           "$env:USERPROFILE\.pyenv\pyenv-win\shims" | Out-File -FilePath $env:GITHUB_PATH -Append
 
-      - name: "Install Python 3.11.9 via pyenv-win"
+      - name: "Find and install available Python 3.11.x via pyenv-win"
+        id: install-python
         shell: pwsh
         run: |
           $env:Path = "$env:USERPROFILE\.pyenv\pyenv-win\bin;$env:USERPROFILE\.pyenv\pyenv-win\shims;$env:Path"
-          pyenv install 3.11.9
-          pyenv global 3.11.9
+
+          # List available versions and find latest 3.11.x (non-dev, non-rc)
+          Write-Host "Available Python 3.11.x versions:"
+          $versions = pyenv install -l | Select-String "^\s*3\.11\.\d+$" | ForEach-Object { $_.Line.Trim() }
+          $versions | ForEach-Object { Write-Host "  $_" }
+
+          # Get the latest 3.11.x version (last one in sorted list)
+          $latestVersion = $versions | Sort-Object { [version]$_ } | Select-Object -Last 1
+          Write-Host "Installing Python $latestVersion"
+
+          pyenv install $latestVersion
+          pyenv global $latestVersion
           pyenv rehash
+
           Write-Host "pyenv-win Python version:"
           python --version
+
+          # Output the version for later steps
+          "PYTHON_VERSION=$latestVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
       - name: "Migrate pyenv-win Python to dtvem"
         shell: bash
@@ -69,18 +84,23 @@ jobs:
 
       - name: "Verify migrated version"
         shell: bash
+        env:
+          EXPECTED_VERSION: ${{ steps.install-python.outputs.PYTHON_VERSION }}
         run: |
-          ./dist/dtvem.exe list python | grep -E "3\.11\.9" || (echo "ERROR: Expected Python 3.11.9 to be migrated" && exit 1)
-          echo "SUCCESS: Python 3.11.9 was migrated from pyenv-win"
+          echo "Looking for Python $EXPECTED_VERSION"
+          ./dist/dtvem.exe list python | grep -E "$EXPECTED_VERSION" || (echo "ERROR: Expected Python $EXPECTED_VERSION to be migrated" && exit 1)
+          echo "SUCCESS: Python $EXPECTED_VERSION was migrated from pyenv-win"
 
       - name: Generate summary
         if: always()
         shell: bash
+        env:
+          EXPECTED_VERSION: ${{ steps.install-python.outputs.PYTHON_VERSION }}
         run: |
           echo "## Python Migration from pyenv-win (Windows)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Source:** pyenv-win" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** 3.11.9" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** $EXPECTED_VERSION" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Installed Versions" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/integration-test-migrate-python-windows-system.yml
+++ b/.github/workflows/integration-test-migrate-python-windows-system.yml
@@ -37,21 +37,21 @@ jobs:
           "$env:USERPROFILE\.dtvem\shims" | Out-File -FilePath $env:GITHUB_PATH -Append
           "$env:USERPROFILE\.dtvem\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
 
-      - name: "Install Python 3.10 via Chocolatey"
+      - name: "Detect pre-installed Python version"
+        id: detect-python
         shell: pwsh
         run: |
-          choco install python310 -y
-          $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
-          Write-Host "System Python installed"
-          python --version
-
-      - name: "Add Chocolatey Python to PATH"
-        shell: pwsh
-        run: |
-          $pythonPath = "C:\Python310"
-          if (Test-Path $pythonPath) {
-            $pythonPath | Out-File -FilePath $env:GITHUB_PATH -Append
-            "$pythonPath\Scripts" | Out-File -FilePath $env:GITHUB_PATH -Append
+          # GitHub runners have Python pre-installed, use that version
+          $pythonVersion = python --version 2>&1
+          Write-Host "Pre-installed Python: $pythonVersion"
+          # Extract version number (e.g., "3.9.13" from "Python 3.9.13")
+          if ($pythonVersion -match "Python (\d+\.\d+\.\d+)") {
+            $version = $Matches[1]
+            Write-Host "Detected version: $version"
+            "PYTHON_VERSION=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          } else {
+            Write-Host "ERROR: Could not detect Python version"
+            exit 1
           }
 
       - name: "Migrate system Python to dtvem"
@@ -66,18 +66,25 @@ jobs:
 
       - name: "Verify migrated version"
         shell: bash
+        env:
+          EXPECTED_VERSION: ${{ steps.detect-python.outputs.PYTHON_VERSION }}
         run: |
-          ./dist/dtvem.exe list python | grep -E "3\.10\." || (echo "ERROR: Expected Python 3.10.x to be migrated" && exit 1)
-          echo "SUCCESS: Python 3.10.x was migrated from system"
+          # Extract major.minor from detected version (e.g., "3.9" from "3.9.13")
+          MAJOR_MINOR=$(echo "$EXPECTED_VERSION" | cut -d. -f1,2)
+          echo "Looking for Python $MAJOR_MINOR.x"
+          ./dist/dtvem.exe list python | grep -E "${MAJOR_MINOR}\." || (echo "ERROR: Expected Python ${MAJOR_MINOR}.x to be migrated" && exit 1)
+          echo "SUCCESS: Python ${MAJOR_MINOR}.x was migrated from system"
 
       - name: Generate summary
         if: always()
         shell: bash
+        env:
+          EXPECTED_VERSION: ${{ steps.detect-python.outputs.PYTHON_VERSION }}
         run: |
           echo "## Python Migration from System (Windows)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Source:** Chocolatey" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** 3.10.x" >> $GITHUB_STEP_SUMMARY
+          echo "**Source:** Pre-installed (GitHub Runner)" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** $EXPECTED_VERSION" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Installed Versions" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Fixed Python migration tests to use versions that are actually available for download
- Windows system: use pre-installed Python (dynamically detected version)
- Ubuntu/macOS system: use actions/setup-python with Python 3.11.9 (available in python-build-standalone)
- pyenv-win: dynamically find and install latest available 3.11.x version

## Root Causes
- Ubuntu/macOS system tests failed because pre-installed Python versions (3.12.3, 3.14.2) aren't in python-build-standalone release 20240814
- Windows system test worked but expected wrong version (3.10.x vs detected 3.9.x)
- pyenv-win test failed because Python 3.11.9 isn't available in pyenv-win

## Test plan
- [ ] All 6 Python migration tests pass:
  - Ubuntu system
  - Ubuntu pyenv
  - macOS system
  - macOS pyenv
  - Windows system
  - Windows pyenv-win