### PR TITLE
fix(ci): add uru to current PATH before admin install

### DIFF
--- a/.github/workflows/integration-test-migrate-ruby-windows-uru.yml
+++ b/.github/workflows/integration-test-migrate-ruby-windows-uru.yml
@@ -66,12 +66,14 @@ jobs:
           Write-Host "Extracting uru..."
           7z x $uruArchive -o"$uruDir" -y
 
-          # Add uru to PATH
+          # Add uru to PATH (for subsequent steps)
           $uruDir | Out-File -FilePath $env:GITHUB_PATH -Append
+          # Also add to current PATH (GITHUB_PATH only affects subsequent steps)
+          $env:Path = "$uruDir;$env:Path"
 
           # Initialize uru
           Write-Host "Installing uru..."
-          & "$uruDir\uru_rt.exe" admin install
+          uru_rt.exe admin install
 
           Write-Host "uru installed successfully"
 


### PR DESCRIPTION
## Summary
- Fixed uru (Windows) Ruby migration test
- `GITHUB_PATH` changes only take effect in subsequent steps
- Added uru directory to current `$env:Path` before running `uru_rt.exe admin install`

## Test plan
- [ ] uru (Windows) Ruby migration test passes