### PR TITLE
fix(ci): run uru admin install from uru directory

### DIFF
--- a/.github/workflows/integration-test-migrate-ruby-windows-uru.yml
+++ b/.github/workflows/integration-test-migrate-ruby-windows-uru.yml
@@ -71,9 +71,11 @@ jobs:
           # Also add to current PATH (GITHUB_PATH only affects subsequent steps)
           $env:Path = "$uruDir;$env:Path"
 
-          # Initialize uru
+          # Initialize uru (must run from same directory as uru_rt.exe)
           Write-Host "Installing uru..."
-          uru_rt.exe admin install
+          Push-Location $uruDir
+          .\uru_rt.exe admin install
+          Pop-Location
 
           Write-Host "uru installed successfully"
 


### PR DESCRIPTION
## Summary
- uru requires `admin install` to run from the same directory as `uru_rt.exe`
- Use `Push-Location`/`Pop-Location` to change to uru directory before running admin install

## Test plan
- [ ] uru (Windows) Ruby migration test passes