### PR TITLE
fix(ci): fix Ruby integration test failures

### DIFF
--- a/.github/workflows/integration-test-migrate-ruby-macos-rbenv.yml
+++ b/.github/workflows/integration-test-migrate-ruby-macos-rbenv.yml
@@ -49,7 +49,8 @@ jobs:
       - name: "Migrate rbenv Ruby to dtvem"
         run: |
           echo "=== Running migrate detection ==="
-          echo -e "1\n0\nn\n" | ./dist/dtvem migrate ruby || true
+          # Select "all" sources and "0" for all versions (rbenv may not be first source)
+          echo -e "all\n0\nn\n" | ./dist/dtvem migrate ruby || true
           echo ""
           echo "=== Verifying migration ==="
           ./dist/dtvem list ruby

--- a/.github/workflows/integration-test-migrate-ruby-ubuntu-rbenv.yml
+++ b/.github/workflows/integration-test-migrate-ruby-ubuntu-rbenv.yml
@@ -57,7 +57,8 @@ jobs:
       - name: "Migrate rbenv Ruby to dtvem"
         run: |
           echo "=== Running migrate detection ==="
-          echo -e "1\n0\nn\n" | ./dist/dtvem migrate ruby || true
+          # Select "all" sources and "0" for all versions (rbenv may not be first source)
+          echo -e "all\n0\nn\n" | ./dist/dtvem migrate ruby || true
           echo ""
           echo "=== Verifying migration ==="
           ./dist/dtvem list ruby

--- a/.github/workflows/integration-test-ruby.yml
+++ b/.github/workflows/integration-test-ruby.yml
@@ -116,8 +116,13 @@ jobs:
           # Verify test versions are available using --filter and stripping ANSI codes
           echo "Verifying test versions are available..."
 
-          # Check version1
+          # Check version1 - handle rate limiting gracefully
           FILTERED=$(./dtvem${{ matrix.ext }} list-all ruby --filter "${{ matrix.version1 }}" 2>&1 | sed 's/\x1B\[[0-9;]*[a-zA-Z]//g')
+          if echo "$FILTERED" | grep -qE "(HTTP 403|HTTP 429|rate limit)"; then
+            echo "⚠ Warning: GitHub API rate limited, skipping version verification"
+            echo "Proceeding with install - it will fail if version doesn't exist"
+            exit 0
+          fi
           if ! echo "$FILTERED" | grep -qF "${{ matrix.version1 }}"; then
             echo "ERROR: Version ${{ matrix.version1 }} not found in available versions"
             echo "Filtered output: $FILTERED"
@@ -125,8 +130,13 @@ jobs:
           fi
           echo "✓ Version ${{ matrix.version1 }} is available"
 
-          # Check version2
+          # Check version2 - handle rate limiting gracefully
           FILTERED=$(./dtvem${{ matrix.ext }} list-all ruby --filter "${{ matrix.version2 }}" 2>&1 | sed 's/\x1B\[[0-9;]*[a-zA-Z]//g')
+          if echo "$FILTERED" | grep -qE "(HTTP 403|HTTP 429|rate limit)"; then
+            echo "⚠ Warning: GitHub API rate limited, skipping version verification"
+            echo "Proceeding with install - it will fail if version doesn't exist"
+            exit 0
+          fi
           if ! echo "$FILTERED" | grep -qF "${{ matrix.version2 }}"; then
             echo "ERROR: Version ${{ matrix.version2 }} not found in available versions"
             echo "Filtered output: $FILTERED"


### PR DESCRIPTION
## Summary
- Use 'all' source selection in rbenv migration tests (macOS and Ubuntu) to handle cases where system Ruby is detected before rbenv
- Handle GitHub API rate limiting (HTTP 403/429) gracefully in Ruby integration test version verification step

## Problem
The integration tests were failing due to:
1. **rbenv migration tests**: On GitHub Actions runners, system Ruby (via Homebrew on macOS) was being detected as the first source instead of rbenv. Using `"1\n0\nn\n"` was selecting the system Ruby (3.3.10) instead of the rbenv-installed version (3.3.6).
2. **Ruby integration test**: GitHub API rate limiting (HTTP 403) was causing `list-all ruby` to fail, which blocked the entire test run.

## Solution
1. Changed rbenv migration tests to use `"all\n0\nn\n"` to select all sources, similar to the uru migration fix in #157
2. Added rate limit detection in Ruby integration tests - if API returns 403/429, skip version verification and proceed with install (which will fail anyway if version doesn't exist)

## Test plan
- [x] `npm run check` passes (format, lint, tests)
- [ ] Re-run integration tests to verify fixes work