### PR TITLE
fix(providers): handle python-build-standalone on Windows

### DIFF
--- a/src/runtimes/python/provider.go
+++ b/src/runtimes/python/provider.go
@@ -91,18 +91,14 @@ func (p *Provider) downloadAndExtract(version, downloadURL, archiveName string) 
 
 // determineSourceDir determines the source directory from extracted archive
 func determineSourceDir(extractDir string) string {
-	if goruntime.GOOS == constants.OSWindows {
-		// Windows embeddable: files are in extractDir root
-		return extractDir
-	}
-
-	// Unix python-build-standalone: files are in python/ subdirectory
+	// python-build-standalone: files are in python/ subdirectory (all platforms)
 	pythonSubdir := filepath.Join(extractDir, "python")
 	if _, err := os.Stat(pythonSubdir); err == nil {
 		return pythonSubdir
 	}
 
 	// Fallback: use extractDir if python/ doesn't exist
+	// (e.g., Windows embeddable packages from python.org have files in root)
 	return extractDir
 }
 
@@ -384,10 +380,10 @@ func (p *Provider) ExecutablePath(version string) (string, error) {
 	// Determine executable name and path based on platform
 	var pythonPath string
 	if goruntime.GOOS == constants.OSWindows {
-		// Windows embeddable package has python.exe in root
+		// Windows: python.exe is in the installation root
 		pythonPath = filepath.Join(installPath, "python.exe")
 	} else {
-		// Unix has python in bin/
+		// Unix: python is in bin/ subdirectory
 		pythonPath = filepath.Join(installPath, "bin", "python")
 	}
 


### PR DESCRIPTION
## Summary
- Fix Python integration test failure on Windows
- Remove Windows-specific case in `determineSourceDir()` that assumed embeddable package format
- python-build-standalone uses `python/` subdirectory on all platforms including Windows

## Problem
The Python integration test on Windows was failing with:
```
dtvem shim error: could not find python 3.11.9 executable: python executable not found at C:\Users\runneradmin\.dtvem\versions\python\3.11.9\python.exe
```

The code was extracting the archive correctly, but then looking for `python.exe` in the wrong location because it skipped the `python/` subdirectory detection on Windows.

## Test plan
- [x] Local unit tests pass
- [ ] CI integration tests pass (Windows Python specifically)

Fixes integration test failure from https://github.com/dtvem/dtvem/actions/runs/20272683524