### PR TITLE
fix(ci): correct go.mod path in update-manifests workflow

### DIFF
--- a/.github/workflows/update-manifests.yml
+++ b/.github/workflows/update-manifests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: 'src/go.mod'
+          go-version-file: 'go.mod'
 
       - name: Generate manifests
         run: |


### PR DESCRIPTION
## Summary
- Fix incorrect go.mod path in update-manifests workflow
- The workflow was looking for `src/go.mod` but the file is in the repo root

## Test plan
- [ ] Merge this PR
- [ ] Run the Update Manifests workflow to verify it works