### PR TITLE
chore(schemas): update old org URLs to CodingWithCalvin

### DIFF
--- a/.dtvem/runtimes.json
+++ b/.dtvem/runtimes.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dtvem/dtvem/main/schemas/runtimes.schema.json",
+  "$schema": "https://raw.githubusercontent.com/CodingWithCalvin/dtvem.cli/main/schemas/runtimes.schema.json",
   "node": "22.0.0",
   "python": "3.8.9",
   "ruby": "3.3.9"

--- a/schemas/manifest.schema.json
+++ b/schemas/manifest.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/dtvem/dtvem/main/schemas/manifest.schema.json",
+  "$id": "https://raw.githubusercontent.com/CodingWithCalvin/dtvem.cli/main/schemas/manifest.schema.json",
   "title": "dtvem Runtime Manifest",
   "description": "Manifest file containing available versions and download URLs for a runtime",
   "type": "object",

--- a/schemas/runtimes.schema.json
+++ b/schemas/runtimes.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/dtvem/dtvem/main/schemas/runtimes.schema.json",
+  "$id": "https://raw.githubusercontent.com/CodingWithCalvin/dtvem.cli/main/schemas/runtimes.schema.json",
   "title": "dtvem Runtimes Configuration",
   "description": "Configuration file for dtvem (Development Tool Virtual Environment Manager) to specify runtime versions for a project",
   "type": "object",

--- a/src/internal/config/version.go
+++ b/src/internal/config/version.go
@@ -12,7 +12,7 @@ import (
 type RuntimesConfig map[string]string
 
 // SchemaURL is the URL to the runtimes.json schema
-const SchemaURL = "https://raw.githubusercontent.com/dtvem/dtvem/main/schemas/runtimes.schema.json"
+const SchemaURL = "https://raw.githubusercontent.com/CodingWithCalvin/dtvem.cli/main/schemas/runtimes.schema.json"
 
 // ResolveVersion finds the version to use for a runtime
 // Priority: local dtvem.config.json file (walking up directory tree) > global config


### PR DESCRIPTION
## Summary

Update schema URLs that were missed in the organization migration (#180):

- `.dtvem/runtimes.json` - `$schema` URL
- `schemas/runtimes.schema.json` - `$id` URL  
- `schemas/manifest.schema.json` - `$id` URL
- `src/internal/config/version.go` - `SchemaURL` constant

All URLs changed from `github.com/dtvem/dtvem` to `github.com/CodingWithCalvin/dtvem.cli`.

## Test plan

- [x] Verified no remaining `github.com/dtvem` references in codebase
- [ ] Build passes