### PR TITLE
feat(install): add partial version number support

### DIFF
--- a/.github/workflows/integration-test-partial-versions.yml
+++ b/.github/workflows/integration-test-partial-versions.yml
@@ -1,0 +1,32 @@
+name: Integration Tests - Partial Versions
+
+on:
+  workflow_dispatch:
+    # Manual trigger for testing partial version resolution
+  push:
+    branches: [main]
+    paths:
+      - 'src/internal/version/**'
+      - 'src/cmd/install.go'
+      - '.github/workflows/integration-test-partial-versions.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/internal/version/**'
+      - 'src/cmd/install.go'
+      - '.github/workflows/integration-test-partial-versions.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  partial-versions:
+    name: Partial Version Resolution
+    uses: CodingWithCalvin/.github/.github/workflows/dtvem-integration-test-partial-versions.yml@main
+    with:
+      node_major: '22'
+      node_major_minor: '20.18'
+      python_major: '3'
+      python_major_minor: '3.12'
+      ruby_major: '3'
+      ruby_major_minor: '3.3'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -36,6 +36,20 @@ jobs:
       version2: '3.4.1'
 
   # ==========================================================================
+  # Partial Version Resolution Tests
+  # ==========================================================================
+  partial-versions:
+    name: Partial Version Resolution
+    uses: CodingWithCalvin/.github/.github/workflows/dtvem-integration-test-partial-versions.yml@main
+    with:
+      node_major: '22'
+      node_major_minor: '20.18'
+      python_major: '3'
+      python_major_minor: '3.12'
+      ruby_major: '3'
+      ruby_major_minor: '3.3'
+
+  # ==========================================================================
   # Migration Tests
   # ==========================================================================
   migrate-node-ubuntu-system:

--- a/src/internal/version/matcher.go
+++ b/src/internal/version/matcher.go
@@ -1,0 +1,141 @@
+// Package version provides utilities for resolving partial version specifications
+// to full semantic versions from a list of available versions.
+package version
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// ResolvePartialVersion finds the latest version matching a partial input.
+// Examples:
+//   - "22" matches "22.0.0", "22.15.0" → returns highest "22.x.x"
+//   - "14.21" matches "14.21.0", "14.21.3" → returns highest "14.21.x"
+//   - "22.0.0" with 3 components → returns "22.0.0" (exact match expected)
+//
+// Returns an error if no matching version is found.
+func ResolvePartialVersion(input string, available []string) (string, error) {
+	input = strings.TrimPrefix(input, "v")
+
+	// Parse input into components
+	inputParts := strings.Split(input, ".")
+
+	// If it's a full semver (3 components), return as-is without validation
+	// The caller is responsible for checking if this exact version exists
+	if len(inputParts) >= 3 {
+		return input, nil
+	}
+
+	// Find all versions that match the partial specification
+	var matches []string
+	for _, v := range available {
+		if matchesPartial(v, inputParts) {
+			matches = append(matches, v)
+		}
+	}
+
+	if len(matches) == 0 {
+		return "", fmt.Errorf("no version matching %q found", input)
+	}
+
+	// Sort matches by semantic version (descending) and return the highest
+	sortVersionsDesc(matches)
+	return matches[0], nil
+}
+
+// IsPartialVersion returns true if the input has fewer than 3 components.
+// Examples:
+//   - "22" → true (1 component)
+//   - "22.15" → true (2 components)
+//   - "22.15.0" → false (3 components)
+//   - "v22" → true (1 component, after stripping v prefix)
+func IsPartialVersion(input string) bool {
+	input = strings.TrimPrefix(input, "v")
+	parts := strings.Split(input, ".")
+	return len(parts) < 3
+}
+
+// matchesPartial checks if a version matches the partial specification.
+// The version must have the same numeric values in the positions specified.
+func matchesPartial(version string, partialParts []string) bool {
+	version = strings.TrimPrefix(version, "v")
+	versionParts := strings.Split(version, ".")
+
+	// Version must have at least as many parts as the partial
+	if len(versionParts) < len(partialParts) {
+		return false
+	}
+
+	// Check each partial component matches
+	for i, partial := range partialParts {
+		// Parse both as integers for numeric comparison
+		partialNum, partialErr := strconv.Atoi(partial)
+		versionNum, versionErr := strconv.Atoi(versionParts[i])
+
+		if partialErr != nil || versionErr != nil {
+			// Fall back to string comparison if not numeric
+			if partial != versionParts[i] {
+				return false
+			}
+		} else if partialNum != versionNum {
+			return false
+		}
+	}
+
+	return true
+}
+
+// sortVersionsDesc sorts version strings by semantic version in descending order.
+func sortVersionsDesc(versions []string) {
+	sort.Slice(versions, func(i, j int) bool {
+		return compareVersionStrings(versions[i], versions[j]) > 0
+	})
+}
+
+// compareVersionStrings compares two version strings semantically.
+// Returns >0 if a > b, <0 if a < b, 0 if equal.
+func compareVersionStrings(a, b string) int {
+	aParts := parseVersionParts(a)
+	bParts := parseVersionParts(b)
+
+	maxLen := len(aParts)
+	if len(bParts) > maxLen {
+		maxLen = len(bParts)
+	}
+
+	for i := 0; i < maxLen; i++ {
+		var aVal, bVal int
+		if i < len(aParts) {
+			aVal = aParts[i]
+		}
+		if i < len(bParts) {
+			bVal = bParts[i]
+		}
+
+		if aVal != bVal {
+			return aVal - bVal
+		}
+	}
+
+	return 0
+}
+
+// parseVersionParts splits a version string into numeric parts.
+func parseVersionParts(version string) []int {
+	version = strings.TrimPrefix(version, "v")
+
+	parts := strings.FieldsFunc(version, func(c rune) bool {
+		return c == '.' || c == '-'
+	})
+
+	var result []int
+	for _, part := range parts {
+		if val, err := strconv.Atoi(part); err == nil {
+			result = append(result, val)
+		}
+	}
+
+	return result
+}

--- a/src/internal/version/matcher_test.go
+++ b/src/internal/version/matcher_test.go
@@ -1,0 +1,277 @@
+package version
+
+import (
+	"testing"
+)
+
+func TestIsPartialVersion(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		// Single component (partial)
+		{"22", true},
+		{"v22", true},
+		{"3", true},
+
+		// Two components (partial)
+		{"22.15", true},
+		{"v22.15", true},
+		{"14.21", true},
+
+		// Three components (full)
+		{"22.15.0", false},
+		{"v22.15.0", false},
+		{"3.11.0", false},
+
+		// More than three components (still considered full)
+		{"22.15.0.1", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := IsPartialVersion(tt.input)
+			if result != tt.expected {
+				t.Errorf("IsPartialVersion(%q) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestResolvePartialVersion_MajorOnly(t *testing.T) {
+	available := []string{
+		"22.0.0",
+		"22.5.0",
+		"22.15.0",
+		"22.15.1",
+		"21.0.0",
+		"20.10.0",
+	}
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"22", "22.15.1"},  // Should find highest 22.x.x
+		{"v22", "22.15.1"}, // Should handle v prefix
+		{"21", "21.0.0"},   // Single match
+		{"20", "20.10.0"},  // Different major
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result, err := ResolvePartialVersion(tt.input, available)
+			if err != nil {
+				t.Errorf("ResolvePartialVersion(%q) returned error: %v", tt.input, err)
+				return
+			}
+			if result != tt.expected {
+				t.Errorf("ResolvePartialVersion(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestResolvePartialVersion_MajorMinor(t *testing.T) {
+	available := []string{
+		"14.21.0",
+		"14.21.3",
+		"14.20.0",
+		"14.20.1",
+		"14.19.0",
+	}
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"14.21", "14.21.3"}, // Should find highest 14.21.x
+		{"14.20", "14.20.1"}, // Different minor
+		{"14.19", "14.19.0"}, // Single match
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result, err := ResolvePartialVersion(tt.input, available)
+			if err != nil {
+				t.Errorf("ResolvePartialVersion(%q) returned error: %v", tt.input, err)
+				return
+			}
+			if result != tt.expected {
+				t.Errorf("ResolvePartialVersion(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestResolvePartialVersion_FullVersion(t *testing.T) {
+	available := []string{
+		"22.15.0",
+		"22.15.1",
+	}
+
+	// Full version should be returned as-is (passthrough)
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"22.15.0", "22.15.0"},
+		{"v22.15.0", "22.15.0"},  // v prefix stripped
+		{"99.99.99", "99.99.99"}, // Not in available list, but still returned (caller validates)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result, err := ResolvePartialVersion(tt.input, available)
+			if err != nil {
+				t.Errorf("ResolvePartialVersion(%q) returned error: %v", tt.input, err)
+				return
+			}
+			if result != tt.expected {
+				t.Errorf("ResolvePartialVersion(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestResolvePartialVersion_NoMatch(t *testing.T) {
+	available := []string{
+		"22.0.0",
+		"21.0.0",
+	}
+
+	tests := []struct {
+		input string
+	}{
+		{"99"},    // Major not found
+		{"22.99"}, // Minor not found
+		{"20"},    // Major not found
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			_, err := ResolvePartialVersion(tt.input, available)
+			if err == nil {
+				t.Errorf("ResolvePartialVersion(%q) expected error, got nil", tt.input)
+			}
+		})
+	}
+}
+
+func TestResolvePartialVersion_EmptyList(t *testing.T) {
+	_, err := ResolvePartialVersion("22", []string{})
+	if err == nil {
+		t.Error("ResolvePartialVersion with empty list expected error, got nil")
+	}
+}
+
+func TestResolvePartialVersion_PythonVersions(t *testing.T) {
+	// Test with Python-style versions
+	available := []string{
+		"3.9.0",
+		"3.9.18",
+		"3.10.0",
+		"3.10.13",
+		"3.11.0",
+		"3.11.7",
+		"3.12.0",
+		"3.12.1",
+	}
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"3", "3.12.1"},    // Latest 3.x.x
+		{"3.11", "3.11.7"}, // Latest 3.11.x
+		{"3.9", "3.9.18"},  // Latest 3.9.x
+		{"3.12", "3.12.1"}, // Latest 3.12.x
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result, err := ResolvePartialVersion(tt.input, available)
+			if err != nil {
+				t.Errorf("ResolvePartialVersion(%q) returned error: %v", tt.input, err)
+				return
+			}
+			if result != tt.expected {
+				t.Errorf("ResolvePartialVersion(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMatchesPartial(t *testing.T) {
+	tests := []struct {
+		version      string
+		partialParts []string
+		expected     bool
+	}{
+		{"22.15.0", []string{"22"}, true},
+		{"22.15.0", []string{"22", "15"}, true},
+		{"22.15.0", []string{"22", "15", "0"}, true},
+		{"22.15.0", []string{"22", "16"}, false},
+		{"22.15.0", []string{"21"}, false},
+		{"v22.15.0", []string{"22"}, true}, // v prefix handled
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			result := matchesPartial(tt.version, tt.partialParts)
+			if result != tt.expected {
+				t.Errorf("matchesPartial(%q, %v) = %v, want %v", tt.version, tt.partialParts, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSortVersionsDesc(t *testing.T) {
+	versions := []string{
+		"22.0.0",
+		"22.15.1",
+		"21.0.0",
+		"22.15.0",
+		"22.5.0",
+	}
+
+	sortVersionsDesc(versions)
+
+	expected := []string{
+		"22.15.1",
+		"22.15.0",
+		"22.5.0",
+		"22.0.0",
+		"21.0.0",
+	}
+
+	for i, v := range versions {
+		if v != expected[i] {
+			t.Errorf("sortVersionsDesc: position %d = %q, want %q", i, v, expected[i])
+		}
+	}
+}
+
+func TestCompareVersionStrings(t *testing.T) {
+	tests := []struct {
+		a        string
+		b        string
+		expected int // >0, <0, or 0
+	}{
+		{"22.15.1", "22.15.0", 1},  // a > b
+		{"22.15.0", "22.15.1", -1}, // a < b
+		{"22.15.0", "22.15.0", 0},  // equal
+		{"22.15.0", "22.5.0", 1},   // 15 > 5
+		{"3.10.0", "3.9.0", 1},     // 10 > 9
+		{"22.0.0", "21.99.99", 1},  // major takes precedence
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.a+"_vs_"+tt.b, func(t *testing.T) {
+			result := compareVersionStrings(tt.a, tt.b)
+			if (tt.expected > 0 && result <= 0) || (tt.expected < 0 && result >= 0) || (tt.expected == 0 && result != 0) {
+				t.Errorf("compareVersionStrings(%q, %q) = %d, want sign of %d", tt.a, tt.b, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add partial version resolution to the install command
- Users can now specify major-only or major.minor versions

## Examples
- `dtvem install node 22` resolves to latest 22.x.x (e.g., 22.15.0)
- `dtvem install python 3.12` resolves to latest 3.12.x (e.g., 3.12.1)
- `dtvem install node 22.0.0` still works as exact version

## Changes
- New `src/internal/version/` package with version matching logic
- Updated `src/cmd/install.go` to resolve partial versions before installation
- Added comprehensive unit tests
- Added e2e integration tests for all runtimes

## Test plan
- [x] Unit tests pass (`go test ./src/...`)
- [x] Linting passes (`npm run check`)
- [ ] E2E tests pass (requires CodingWithCalvin/.github#36 to be merged first)

Closes #188
