### PR TITLE
fix(ci): simplify preview changelog workflow

### DIFF
--- a/.github/workflows/preview-changelog.yml
+++ b/.github/workflows/preview-changelog.yml
@@ -6,24 +6,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  generate:
-    name: Generate
+  preview:
+    name: Preview
     uses: CodingWithCalvin/.github/.github/workflows/generate-changelog.yml@main
     secrets: inherit
 
-  preview:
-    name: Display Preview
-    runs-on: ubuntu-latest
-    needs: generate
-
-    steps:
-    - name: Display changelog preview
-      run: |
-        echo "=========================================="
-        echo "CHANGELOG PREVIEW"
-        echo "=========================================="
-        echo ""
-        echo "## What's New in v<VERSION>"
-        echo ""
-        echo "${{ needs.generate.outputs.changelog }}"
-      shell: bash


### PR DESCRIPTION
## Summary

- Simplify preview changelog workflow to just call the reusable generate-changelog workflow
- Removes redundant preview job that re-echoed the changelog
- Fixes potential issue where backticks in changelog content could be interpreted as shell command substitution

The changelog output is already visible in the generate job's logs.