### PR TITLE
fix(config): allow version resolution to traverse through .git

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,7 +223,7 @@ The shim mappings are automatically registered via `Shims()`.
 ## Version Resolution
 
 **Priority order:**
-1. **Local**: Walk up from `pwd` looking for `.dtvem/runtimes.json` (stops at git root)
+1. **Local**: Walk up from `pwd` looking for `.dtvem/runtimes.json` (stops at filesystem root)
 2. **Global**: `~/.dtvem/config/runtimes.json`
 3. **Error**: No version configured
 
@@ -282,7 +282,7 @@ cd src && go test -cover ./...    # With coverage
 
 ### Test Coverage
 
-- `internal/config/` - Paths, version resolution, git root detection
+- `internal/config/` - Paths, version resolution, directory traversal
 - `internal/runtime/` - Registry, provider test harness
 - `internal/shim/` - Shim mapping, cache, file operations
 - `internal/ui/` - Output formatting functions

--- a/src/internal/config/version.go
+++ b/src/internal/config/version.go
@@ -33,7 +33,7 @@ func ResolveVersion(runtimeName string) (string, error) {
 }
 
 // findLocalVersion walks up the directory tree looking for .dtvem/runtimes.json file
-// Stops at git repository root or filesystem root
+// Stops at filesystem root
 func findLocalVersion(runtimeName string) (string, error) {
 	// Start from current working directory
 	currentDir, err := os.Getwd()
@@ -52,13 +52,6 @@ func findLocalVersion(runtimeName string) (string, error) {
 			if err == nil && version != "" {
 				return version, nil
 			}
-		}
-
-		// Check if this directory contains a .git directory (repository root)
-		gitDir := filepath.Join(currentDir, ".git")
-		if _, err := os.Stat(gitDir); err == nil {
-			// We've reached the git repository root, stop here
-			break
 		}
 
 		// Move up one directory
@@ -128,13 +121,6 @@ func FindLocalRuntimesFile() (string, error) {
 		// Check if .dtvem/runtimes.json exists
 		if _, err := os.Stat(versionFile); err == nil {
 			return versionFile, nil
-		}
-
-		// Check if this directory contains a .git directory (repository root)
-		gitDir := filepath.Join(currentDir, ".git")
-		if _, err := os.Stat(gitDir); err == nil {
-			// We've reached the git repository root, stop here
-			break
 		}
 
 		// Move up one directory

--- a/src/internal/download/extract.go
+++ b/src/internal/download/extract.go
@@ -10,8 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/bodgit/sevenzip"
 	"github.com/CodingWithCalvin/dtvem.cli/src/internal/ui"
+	"github.com/bodgit/sevenzip"
 )
 
 // archiveFile is an interface for files within an archive (zip or 7z)


### PR DESCRIPTION
## Summary
- Remove git root stopping logic from `findLocalVersion()` and `FindLocalRuntimesFile()`
- Update test to verify config files in parent directories are found even when inside a git repository
- Update CLAUDE.md documentation to reflect new behavior

## Test plan
- [x] All existing unit tests pass
- [x] New test `TestFindLocalRuntimesFile_TraversesThroughGitRoot` verifies the fix
- [ ] Manual testing: set local version in parent folder, verify it's used in git repo subfolders

Fixes #195