### PR TITLE
feat(social): add X posting on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -377,3 +377,21 @@ jobs:
       BLUESKY_USERNAME: ${{ secrets.BLUESKY_USERNAME }}
       BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}
 
+  notify-x:
+    name: Post to X
+    needs: notify-discussion
+    uses: CodingWithCalvin/.github/.github/workflows/x-post.yml@main
+    with:
+      post_text: |
+        🚀 #dtvem v${{ github.event.inputs.version }} is now available!
+
+        Cross-platform version manager for #Node, #Python, and #Ruby - supports #Windows, #Linux, and #macOS
+
+        Release Notes: https://github.com/${{ github.repository }}/releases/tag/v${{ github.event.inputs.version }}
+        Discussion: ${{ needs.notify-discussion.outputs.discussion_url }}
+    secrets:
+      X_CONSUMER_KEY: ${{ secrets.X_CONSUMER_KEY }}
+      X_CONSUMER_KEY_SECRET: ${{ secrets.X_CONSUMER_KEY_SECRET }}
+      X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}
+      X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
+


### PR DESCRIPTION
## Summary
- Add `notify-x` job to post releases to X alongside BlueSky

## Required Secrets
- `X_CONSUMER_KEY`
- `X_CONSUMER_KEY_SECRET`
- `X_ACCESS_TOKEN`
- `X_ACCESS_TOKEN_SECRET`

## Test plan
- [ ] Merge after .github x-post.yml is available
- [ ] Configure X secrets in repo settings