### PR TITLE
fix(ci): use CONTRIBUTORS_TOKEN for manifest commits

### DIFF
--- a/.github/workflows/generate-manifests-from-r2.yml
+++ b/.github/workflows/generate-manifests-from-r2.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.CONTRIBUTORS_TOKEN }}
 
       - name: Setup Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
## Summary
- Use `CONTRIBUTORS_TOKEN` secret for checkout in manifest generation workflow
- This allows the workflow to push directly to main, bypassing branch protection rules

Fixes the "Changes must be made through a pull request" error from the previous workflow run.