### PR TITLE
fix(ci): only trigger builds on code changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,46 +4,20 @@ on:
   workflow_dispatch:
   push:
     branches: [ main ]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'assets/**'
-      - 'schemas/**'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/workflows/generate-changelog.yml'
-      - '.github/workflows/preview-changelog.yml'
-      - '.github/workflows/contributors.yml'
-      - '.github/workflows/integration-test*.yml'
-      - '.idea/**'
-      - '.claude/**'
-      - '.gitignore'
-      - '.commitlintrc.yml'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'LICENSE'
-      - 'install.sh'
-      - 'install.ps1'
+    paths:
+      - 'src/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.golangci.yml'
+      - '.github/workflows/build.yml'
   pull_request:
     branches: [ main ]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'assets/**'
-      - 'schemas/**'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/workflows/generate-changelog.yml'
-      - '.github/workflows/preview-changelog.yml'
-      - '.github/workflows/contributors.yml'
-      - '.github/workflows/integration-test*.yml'
-      - '.idea/**'
-      - '.claude/**'
-      - '.gitignore'
-      - '.commitlintrc.yml'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'LICENSE'
-      - 'install.sh'
-      - 'install.ps1'
+    paths:
+      - 'src/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.golangci.yml'
+      - '.github/workflows/build.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Switch from `paths-ignore` to `paths` in build workflow
- Only trigger builds when actual code changes:
  - `src/**` - Go source code
  - `go.mod` / `go.sum` - Dependencies
  - `.golangci.yml` - Linter config
  - `.github/workflows/build.yml` - The build workflow itself

This prevents unnecessary CI runs when modifying other workflows, documentation, or config files.