### PR TITLE
fix(ci): rebase before pushing manifest changes

### DIFF
--- a/.github/workflows/generate-manifests-from-r2.yml
+++ b/.github/workflows/generate-manifests-from-r2.yml
@@ -121,6 +121,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add src/internal/manifest/data/
           git commit -m "chore(manifest): regenerate manifests from R2"
+          git pull --rebase origin main
           git push
 
       - name: Generate summary


### PR DESCRIPTION
## Summary
- Add `git pull --rebase origin main` before pushing manifest changes
- Prevents push failures when other PRs are merged during workflow execution