### PR TITLE
feat(ci): add changelog to workflow step summary

### DIFF
--- a/.github/workflows/preview-changelog.yml
+++ b/.github/workflows/preview-changelog.yml
@@ -11,3 +11,14 @@ jobs:
     uses: CodingWithCalvin/.github/.github/workflows/generate-changelog.yml@main
     secrets: inherit
 
+  summary:
+    name: Summary
+    needs: preview
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write changelog to summary
+        run: |
+          echo "## 📋 Preview Release Notes" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "${{ needs.preview.outputs.changelog }}" >> $GITHUB_STEP_SUMMARY
+


### PR DESCRIPTION
## Summary
- Add a summary job that writes the generated changelog to the GitHub Actions step summary
- Makes it easy to view the preview changelog directly in the workflow run

The reusable workflow already outputs the changelog, this just displays it in the summary.