### PR TITLE
fix(ci): stash changes before rebase in manifest workflow

### DIFF
--- a/.github/workflows/generate-manifests-from-r2.yml
+++ b/.github/workflows/generate-manifests-from-r2.yml
@@ -119,9 +119,11 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git stash --include-untracked
+          git pull --rebase origin main
+          git stash pop
           git add src/internal/manifest/data/
           git commit -m "chore(manifest): regenerate manifests from R2"
-          git pull --rebase origin main
           git push
 
       - name: Generate summary


### PR DESCRIPTION
## Summary
- Stash all local changes (including built binary) before pulling with rebase
- Pop stash after rebase, then add only manifest data and commit

Fixes "cannot pull with rebase: You have unstaged changes" error caused by the built manifest generator binary.