### PR TITLE
fix(config): return ("", nil) from GlobalVersion when unconfigured

### DIFF
--- a/src/internal/config/version_test.go
+++ b/src/internal/config/version_test.go
@@ -442,6 +442,46 @@ func TestSetGlobalVersion_MultipleRuntimes(t *testing.T) {
 	}
 }
 
+func TestGlobalVersion_NoConfigFile(t *testing.T) {
+	// On a clean system with no config file, GlobalVersion should return ("", nil)
+	tmpRoot := t.TempDir()
+	t.Setenv("HOME", tmpRoot)
+	t.Setenv("USERPROFILE", tmpRoot)
+	ResetPathsCache()
+	defer ResetPathsCache()
+
+	version, err := GlobalVersion("python")
+	if err != nil {
+		t.Errorf("GlobalVersion() with no config file should return nil error, got: %v", err)
+	}
+	if version != "" {
+		t.Errorf("GlobalVersion() with no config file should return empty string, got: %q", version)
+	}
+}
+
+func TestGlobalVersion_RuntimeNotInConfig(t *testing.T) {
+	// When config exists but runtime is not in it, GlobalVersion should return ("", nil)
+	tmpRoot := t.TempDir()
+	t.Setenv("HOME", tmpRoot)
+	t.Setenv("USERPROFILE", tmpRoot)
+	ResetPathsCache()
+	defer ResetPathsCache()
+
+	// Set a version for python so the config file exists
+	if err := SetGlobalVersion("python", "3.11.0"); err != nil {
+		t.Fatalf("SetGlobalVersion() setup error: %v", err)
+	}
+
+	// Ask for node which is not in the config
+	version, err := GlobalVersion("node")
+	if err != nil {
+		t.Errorf("GlobalVersion() for missing runtime should return nil error, got: %v", err)
+	}
+	if version != "" {
+		t.Errorf("GlobalVersion() for missing runtime should return empty string, got: %q", version)
+	}
+}
+
 func TestSetLocalVersion_CreatesDirectoryAndFile(t *testing.T) {
 	// Create temp directory and change to it
 	tmpRoot := t.TempDir()

--- a/src/internal/runtime/provider_test_harness.go
+++ b/src/internal/runtime/provider_test_harness.go
@@ -250,10 +250,14 @@ func (h *ProviderTestHarness) TestIsInstalled(t *testing.T) {
 func (h *ProviderTestHarness) TestGetGlobalVersion(t *testing.T) {
 	version, err := h.Provider.GlobalVersion()
 
-	// It's OK to have error if no global version is set
-	// But if version is returned, it should be non-empty
-	if err == nil && version == "" {
-		t.Error("GetGlobalVersion() returned empty string without error")
+	// ("", nil) is valid — means no global version configured
+	// If a version is returned, it should be non-empty
+	if err == nil && version != "" {
+		// Valid: a global version is configured
+	}
+	if err != nil {
+		// Valid: an actual error occurred (I/O, corrupt config)
+		t.Logf("GetGlobalVersion() returned error (may be expected): %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Fixed** `config.GlobalVersion()` returning an error for "unconfigured" states (missing config file, runtime not in config), which caused `autoSetGlobalIfNeeded()` to skip auto-setting the global version on the first install of a runtime on a clean system
- Changed `GlobalVersion()` to return `("", nil)` for unconfigured states, reserving errors for actual failures (I/O errors, corrupt JSON)
- Updated provider test harness to accept `("", nil)` as valid from `GlobalVersion()`
- Added tests for clean system scenarios and I/O error handling

## Test plan

- [x] `TestGlobalVersion_NoConfigFile` — verifies `("", nil)` when no config file exists
- [x] `TestGlobalVersion_RuntimeNotInConfig` — verifies `("", nil)` when runtime is absent from config
- [x] `TestAutoSetGlobalIfNeeded_GlobalVersionError` — verifies auto-global is skipped on real errors
- [x] All existing tests pass (`go test ./...`)
- [x] `go vet ./...` clean

Closes #220