### PR TITLE
fix(path): respect XDG_DATA_HOME on macOS and Windows

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -12,10 +12,13 @@ $ErrorActionPreference = "Stop"
 $REPO = "CodingWithCalvin/dtvem.cli"
 
 # Get dtvem root directory
-# Respects DTVEM_ROOT environment variable if set, otherwise uses default
+# Respects DTVEM_ROOT environment variable if set, XDG_DATA_HOME if set, otherwise uses default
 function Get-DtvemRoot {
     if ($env:DTVEM_ROOT) {
         return $env:DTVEM_ROOT
+    }
+    if ($env:XDG_DATA_HOME) {
+        return "$env:XDG_DATA_HOME\dtvem"
     }
     return "$env:USERPROFILE\.dtvem"
 }

--- a/install.sh
+++ b/install.sh
@@ -53,7 +53,7 @@ warning() {
 
 # Get dtvem root directory
 # On Linux, respects XDG_DATA_HOME if set (defaults to ~/.local/share/dtvem)
-# On macOS, uses ~/.dtvem
+# On macOS, uses XDG_DATA_HOME if explicitly set (opt-in), otherwise ~/.dtvem
 get_dtvem_root() {
     # Check for DTVEM_ROOT environment variable first (overrides all)
     if [ -n "$DTVEM_ROOT" ]; then
@@ -73,8 +73,12 @@ get_dtvem_root() {
             echo "$HOME/.local/share/dtvem"
         fi
     else
-        # macOS and others: use ~/.dtvem
-        echo "$HOME/.dtvem"
+        # macOS and others: use XDG_DATA_HOME if explicitly set (opt-in)
+        if [ -n "$XDG_DATA_HOME" ]; then
+            echo "$XDG_DATA_HOME/dtvem"
+        else
+            echo "$HOME/.dtvem"
+        fi
     fi
 }
 

--- a/src/internal/path/path.go
+++ b/src/internal/path/path.go
@@ -57,7 +57,12 @@ func ShimsDir() string {
 		return filepath.Join(home, ".local", "share", "dtvem", "shims")
 	}
 
-	// On macOS and Windows, use ~/.dtvem
+	// On macOS and Windows, use XDG_DATA_HOME if explicitly set (opt-in)
+	if xdgDataHome := os.Getenv("XDG_DATA_HOME"); xdgDataHome != "" {
+		return filepath.Join(xdgDataHome, "dtvem", "shims")
+	}
+
+	// Default for macOS and Windows: ~/.dtvem
 	return filepath.Join(home, ".dtvem", "shims")
 }
 


### PR DESCRIPTION
## Summary

- `ShimsDir()` in `path/path.go`, `get_dtvem_root()` in `install.sh`, and `Get-DtvemRoot` in `install.ps1` were not checking `XDG_DATA_HOME` on macOS/Windows, causing `dtvem init` to add wrong paths (`~/.dtvem/bin` and `~/.dtvem/shims`) to PATH when `XDG_DATA_HOME` was set
- Added `XDG_DATA_HOME` opt-in checks to all three locations, bringing them in sync with the canonical `getRootDir()` logic in `config/paths.go`
- Added 4 new tests for `ShimsDir()` covering DTVEM_ROOT override, XDG on non-Linux, no-XDG fallback, and DTVEM_ROOT-over-XDG precedence

Closes #202

## Test plan

- [ ] Verify `go vet ./...` passes
- [ ] Verify `go test ./...` passes (including new ShimsDir XDG tests)
- [ ] Verify `golangci-lint run ./...` reports 0 issues
- [ ] CI build passes on all platforms (Windows, macOS, Linux)