### PR TITLE
fix(node): keep odd versions Current through maintenance window

### DIFF
--- a/src/runtimes/node/lifecycle.go
+++ b/src/runtimes/node/lifecycle.go
@@ -91,8 +91,10 @@ func (lp *lifecycleProvider) resolve(e scheduleEntry) string {
 		if e.LTS != "" {
 			return string(lifecycle.MaintenanceLTS)
 		}
-		// Odd releases enter "maintenance" before EOL but are not LTS.
-		return string(lifecycle.EOL)
+		// Odd releases have a maintenance window before EOL but are not LTS;
+		// keep them labeled Current until their end date so the display
+		// matches nodejs.org's release schedule page.
+		return string(lifecycle.Current)
 	}
 
 	if lts := parseDate(e.LTS); !lts.IsZero() && !today.Before(lts) {

--- a/src/runtimes/node/lifecycle_test.go
+++ b/src/runtimes/node/lifecycle_test.go
@@ -55,16 +55,25 @@ func TestLifecycleProvider_VersionStatus(t *testing.T) {
 			want:    string(lifecycle.Current),
 		},
 		{
-			name:    "v23 odd version in maintenance is EOL (not LTS)",
+			name:    "v23 odd version in maintenance window is still Current (not LTS)",
 			now:     "2025-04-15",
 			version: "23.5.0",
-			want:    string(lifecycle.EOL),
+			want:    string(lifecycle.Current),
 		},
 		{
 			name:    "v23 after end is EOL",
 			now:     "2025-07-01",
 			version: "23.5.0",
 			want:    string(lifecycle.EOL),
+		},
+		// v25: start 2025-10-15, maintenance 2026-04-01, end 2026-06-01 (no LTS)
+		// Regression for #241: odd version past maintenance but before end
+		// should show as Current, not EOL.
+		{
+			name:    "v25 past maintenance but before end is Current",
+			now:     "2026-04-20",
+			version: "25.9.0",
+			want:    string(lifecycle.Current),
 		},
 		// Edge cases
 		{


### PR DESCRIPTION
## Summary

- `dtvem list-all node` was marking v25.x as **EOL** even though Node.js still lists it as **Current** (v26 hasn't released yet, v25's actual end date is 2026-06-01).
- Root cause: in `src/runtimes/node/lifecycle.go`, any odd (non-LTS) release that passed its `maintenance` date was short-circuited to `EOL`, skipping the ~2-month maintenance window before `end`.
- Fix: for odd versions, treat the post-maintenance / pre-end window as **Current** to match nodejs.org's release schedule page. Even versions still transition to Maintenance LTS, and any version past `end` is still EOL.

Resolves [DTVEM-241](https://github.com/CodingWithCalvin/dtvem.cli/issues/241)

## Test plan

- [x] Updated `TestLifecycleProvider_VersionStatus/v23_odd_version_in_maintenance_window_is_still_Current`
- [x] Added regression case `v25_past_maintenance_but_before_end_is_Current` (now=2026-04-20, v25.9.0)
- [x] `./rnr check` passes (format, lint, full test suite)
- [ ] Run `dtvem list-all node` against a real install and confirm v25.x rows now read `Current`