### PR TITLE
ci(node): add weekly workflow to refresh release schedule

### DIFF
--- a/.github/workflows/refresh-node-schedule.yml
+++ b/.github/workflows/refresh-node-schedule.yml
@@ -1,0 +1,57 @@
+name: Refresh Node.js Schedule
+
+on:
+  # Run weekly to pick up upstream changes (e.g., new major lines, revised EOL dates)
+  schedule:
+    - cron: '0 6 * * 1'  # Every Monday at 6 AM UTC
+  # Manual trigger
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  refresh:
+    name: Refresh Node.js release schedule
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.CONTRIBUTORS_TOKEN }}
+
+      - name: Download upstream schedule
+        run: |
+          curl -fsSL \
+            https://raw.githubusercontent.com/nodejs/Release/main/schedule.json \
+            -o src/runtimes/node/data/schedule.json
+
+      - name: Check for changes
+        id: check-changes
+        run: |
+          if git diff --quiet src/runtimes/node/data/schedule.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push changes
+        if: ${{ steps.check-changes.outputs.changed == 'true' }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add src/runtimes/node/data/schedule.json
+          git commit -m "chore(node): refresh upstream release schedule"
+          git push
+
+      - name: Generate summary
+        if: always()
+        run: |
+          echo "## Node.js Release Schedule Refresh" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.check-changes.outputs.changed }}" = "true" ]; then
+            echo "**Result:** Schedule updated from upstream and committed to main." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "**Result:** No changes — embedded schedule is in sync with upstream." >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
## Summary

- `src/runtimes/node/data/schedule.json` (the embedded Node.js release schedule used by the lifecycle resolver) was committed once in #238 and had no refresh mechanism.
- Upstream at `nodejs/Release` gets revised (new majors, shifted EOL dates, revised maintenance windows), so the embedded copy will silently drift.
- This workflow pulls the upstream `schedule.json` every Monday at 06:00 UTC and commits it only if it differs, using the same direct-commit-to-main pattern as `generate-manifests-from-r2.yml`.

## Test plan

- [ ] Manually dispatch the workflow (`Actions → Refresh Node.js Schedule → Run workflow`) and confirm the job summary reads "No changes" (file was verified in sync during the #241 investigation)
- [ ] Verify `CONTRIBUTORS_TOKEN` has push permission (reused from the manifests workflow, so should be fine)
- [ ] Optional: temporarily edit a byte of `schedule.json` on a throwaway branch and dispatch to confirm the commit step fires