### PR TITLE
fix(init): clean up stale dtvem shims entries from PATH

### DIFF
--- a/src/internal/path/path.go
+++ b/src/internal/path/path.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/CodingWithCalvin/dtvem.cli/src/internal/constants"
 )
 
 // IsInPath checks if a directory is in the system PATH
@@ -14,7 +16,7 @@ func IsInPath(dir string) bool {
 
 	// Get the path separator for this OS
 	separator := ":"
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == constants.OSWindows {
 		separator = ";"
 	}
 
@@ -32,6 +34,79 @@ func IsInPath(dir string) bool {
 	}
 
 	return false
+}
+
+// IsDtvemShimsPath reports whether path looks like a dtvem shims directory.
+// It matches the standard installation patterns:
+//   - <anything>/dtvem/shims  (e.g., ~/.local/share/dtvem/shims under XDG_DATA_HOME)
+//   - <anything>/.dtvem/shims (the default Windows/macOS layout, leading dot)
+//
+// Comparison is case-insensitive on Windows. Custom DTVEM_ROOT layouts whose
+// final two components don't match these patterns are not detected.
+func IsDtvemShimsPath(path string) bool {
+	if path == "" {
+		return false
+	}
+
+	cleaned := filepath.Clean(path)
+	leaf := filepath.Base(cleaned)
+	parent := filepath.Base(filepath.Dir(cleaned))
+
+	leafEq := func(a, b string) bool { return a == b }
+	if runtime.GOOS == constants.OSWindows {
+		leafEq = strings.EqualFold
+	}
+
+	if !leafEq(leaf, "shims") {
+		return false
+	}
+	return leafEq(parent, "dtvem") || leafEq(parent, ".dtvem")
+}
+
+// FindStaleShimsEntries scans pathEntries for entries that look like dtvem
+// shims directories but do not match currentShimsDir. The returned slice
+// preserves the order of appearance in pathEntries and has the original
+// (un-cleaned) entry strings, so callers can match them against registry
+// or config-file content.
+//
+// Comparison against currentShimsDir is case-insensitive on Windows.
+func FindStaleShimsEntries(pathEntries []string, currentShimsDir string) []string {
+	if currentShimsDir == "" {
+		return nil
+	}
+	currentClean := filepath.Clean(currentShimsDir)
+
+	var stale []string
+	for _, entry := range pathEntries {
+		trimmed := strings.TrimSpace(entry)
+		if trimmed == "" {
+			continue
+		}
+		if !IsDtvemShimsPath(trimmed) {
+			continue
+		}
+		entryClean := filepath.Clean(trimmed)
+		if runtime.GOOS == constants.OSWindows {
+			if strings.EqualFold(entryClean, currentClean) {
+				continue
+			}
+		} else {
+			if entryClean == currentClean {
+				continue
+			}
+		}
+		stale = append(stale, entry)
+	}
+	return stale
+}
+
+// SplitPath splits the PATH environment variable using the OS-appropriate separator.
+func SplitPath(pathEnv string) []string {
+	separator := ":"
+	if runtime.GOOS == constants.OSWindows {
+		separator = ";"
+	}
+	return strings.Split(pathEnv, separator)
 }
 
 // ShimsDir returns the path to the shims directory
@@ -103,7 +178,7 @@ func LookPathExcludingShims(execName string) string {
 // On Windows, it tries .exe, .cmd, .bat extensions.
 // On Unix, it checks if the file exists and has execute permission.
 func findExecutableInDir(dir, execName string) string {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == constants.OSWindows {
 		// Windows: try .exe, .cmd, .bat extensions
 		for _, ext := range []string{".exe", ".cmd", ".bat"} {
 			candidate := filepath.Join(dir, execName+ext)

--- a/src/internal/path/path_test.go
+++ b/src/internal/path/path_test.go
@@ -372,6 +372,167 @@ func TestLookPathExcludingShims_SkipsShimsDir(t *testing.T) {
 	})
 }
 
+func TestIsDtvemShimsPath(t *testing.T) {
+	// Platform-specific path separator handling: filepath.Join produces
+	// backslashes on Windows and forward slashes on Unix, which matches what
+	// real PATH entries look like on each platform.
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{
+			name: "leading-dot dtvem under home",
+			path: filepath.Join("C:", "Users", "testuser", ".dtvem", "shims"),
+			want: true,
+		},
+		{
+			name: "no-dot dtvem under XDG data home",
+			path: filepath.Join("C:", "Users", "testuser", ".local", "share", "dtvem", "shims"),
+			want: true,
+		},
+		{
+			name: "unix style leading-dot",
+			path: "/home/testuser/.dtvem/shims",
+			want: true,
+		},
+		{
+			name: "unix style XDG",
+			path: "/home/testuser/.local/share/dtvem/shims",
+			want: true,
+		},
+		{
+			name: "trailing slash is normalized",
+			path: "/home/testuser/.dtvem/shims/",
+			want: true,
+		},
+		{
+			name: "shims under non-dtvem parent does not match",
+			path: "/home/testuser/something/shims",
+			want: false,
+		},
+		{
+			name: "dtvem dir without shims leaf does not match",
+			path: "/home/testuser/.dtvem/bin",
+			want: false,
+		},
+		{
+			name: "empty string",
+			path: "",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsDtvemShimsPath(tt.path)
+			if got != tt.want {
+				t.Errorf("IsDtvemShimsPath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsDtvemShimsPath_WindowsCaseInsensitive(t *testing.T) {
+	if runtime.GOOS != constants.OSWindows {
+		t.Skip("Windows-only: case-insensitive path matching")
+	}
+
+	cases := []string{
+		`C:\Users\testuser\.DTVEM\Shims`,
+		`C:\Users\testuser\.local\share\DTVEM\SHIMS`,
+		`C:\Users\testuser\.Dtvem\shims`,
+	}
+	for _, p := range cases {
+		if !IsDtvemShimsPath(p) {
+			t.Errorf("IsDtvemShimsPath(%q) = false, want true (Windows case-insensitive)", p)
+		}
+	}
+}
+
+func TestFindStaleShimsEntries(t *testing.T) {
+	// Build paths that look right on the current platform so the
+	// case-insensitive comparison logic exercises real separators.
+	currentXDG := filepath.Join("C:", "Users", "testuser", ".local", "share", "dtvem", "shims")
+	staleHome := filepath.Join("C:", "Users", "testuser", ".dtvem", "shims")
+	unrelated := filepath.Join("C:", "Windows", "System32")
+
+	tests := []struct {
+		name    string
+		entries []string
+		current string
+		want    []string
+	}{
+		{
+			name:    "stale leading-dot entry alongside current XDG",
+			entries: []string{currentXDG, unrelated, staleHome},
+			current: currentXDG,
+			want:    []string{staleHome},
+		},
+		{
+			name:    "no stale entries when only current is present",
+			entries: []string{currentXDG, unrelated},
+			current: currentXDG,
+			want:    nil,
+		},
+		{
+			name:    "current dir is the leading-dot variant",
+			entries: []string{staleHome, currentXDG, unrelated},
+			current: staleHome,
+			want:    []string{currentXDG},
+		},
+		{
+			name:    "empty entries are skipped",
+			entries: []string{"", staleHome, "  "},
+			current: currentXDG,
+			want:    []string{staleHome},
+		},
+		{
+			name:    "preserves original entry strings (not cleaned)",
+			entries: []string{staleHome + string(filepath.Separator), unrelated},
+			current: currentXDG,
+			want:    []string{staleHome + string(filepath.Separator)},
+		},
+		{
+			name:    "empty current shimsDir returns nil",
+			entries: []string{staleHome},
+			current: "",
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FindStaleShimsEntries(tt.entries, tt.current)
+			if len(got) != len(tt.want) {
+				t.Fatalf("FindStaleShimsEntries() = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("FindStaleShimsEntries()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestFindStaleShimsEntries_WindowsCaseInsensitive(t *testing.T) {
+	if runtime.GOOS != constants.OSWindows {
+		t.Skip("Windows-only: case-insensitive comparison")
+	}
+
+	current := `C:\Users\testuser\.local\share\dtvem\shims`
+	// Same logical path as `current` but with mixed casing — should NOT be
+	// flagged stale.
+	sameAsCurrentDifferentCase := `C:\Users\TESTUSER\.LOCAL\share\dtvem\SHIMS`
+	stale := `C:\Users\testuser\.dtvem\shims`
+
+	got := FindStaleShimsEntries([]string{sameAsCurrentDifferentCase, stale}, current)
+	if len(got) != 1 || got[0] != stale {
+		t.Errorf("FindStaleShimsEntries() = %v, want exactly [%q]", got, stale)
+	}
+}
+
 func TestFindExecutableInDir(t *testing.T) {
 	tempDir := t.TempDir()
 

--- a/src/internal/path/path_unix.go
+++ b/src/internal/path/path_unix.go
@@ -68,6 +68,12 @@ func AddToPath(shimsDir string, skipConfirmation bool, userInstall bool) error {
 		return fmt.Errorf("could not determine config file for shell %s", shell)
 	}
 
+	// Warn about any stale dtvem shims directories in PATH (e.g. left over
+	// after switching XDG_DATA_HOME or upgrading from a pre-XDG install).
+	// We don't auto-rewrite shell config files on Unix because users often
+	// customize them heavily; surface the entries with manual cleanup steps.
+	warnAboutStaleShimsEntries(shimsDir, configFile)
+
 	// Check if the directory is already in PATH
 	if IsInPath(shimsDir) {
 		ui.Info("%s is already in your PATH", shimsDir)
@@ -132,6 +138,25 @@ func AddToPath(shimsDir string, skipConfirmation bool, userInstall bool) error {
 	ui.Warning("Please restart your terminal or run: source %s", configFile)
 
 	return nil
+}
+
+// warnAboutStaleShimsEntries scans the current PATH for dtvem shims directories
+// that don't match shimsDir and prints manual cleanup instructions for each.
+// We don't auto-rewrite shell config files on Unix to avoid clobbering user edits.
+func warnAboutStaleShimsEntries(shimsDir, configFile string) {
+	stale := FindStaleShimsEntries(SplitPath(os.Getenv("PATH")), shimsDir)
+	if len(stale) == 0 {
+		return
+	}
+
+	ui.Warning("Found stale dtvem shims entries in your PATH:")
+	for _, s := range stale {
+		ui.Info("  %s", s)
+	}
+	ui.Info("These were likely left over from a prior install or before XDG_DATA_HOME was set.")
+	ui.Info("Edit %s and remove the export lines that reference the stale paths above.", ui.Highlight(configFile))
+	ui.Info("After editing, restart your terminal or run: source %s", configFile)
+	ui.Info("")
 }
 
 // containsPathModification checks if the config file already has dtvem PATH modification

--- a/src/internal/path/path_windows.go
+++ b/src/internal/path/path_windows.go
@@ -129,8 +129,16 @@ func checkSystemPath(shimsDir string) (bool, string, error) {
 		}
 	}
 
+	// Even if shimsDir is in the right place, stale dtvem shims entries
+	// from prior installs (e.g. ~/.dtvem/shims left behind after switching
+	// to XDG_DATA_HOME) need to be cleaned up.
+	hasStale := len(FindStaleShimsEntries(paths, shimsDir)) > 0
+
 	if foundAt == 0 {
-		return false, "", nil // Already at beginning
+		if hasStale {
+			return true, pathActionMove, nil
+		}
+		return false, "", nil // Already at beginning, nothing stale
 	} else if foundAt > 0 {
 		return true, pathActionMove, nil // Exists but not at beginning
 	}
@@ -167,8 +175,15 @@ func checkUserPath(shimsDir string) (bool, string, error) {
 		}
 	}
 
+	// Even if shimsDir is in the right place, stale dtvem shims entries
+	// from prior installs need to be cleaned up.
+	hasStale := len(FindStaleShimsEntries(paths, shimsDir)) > 0
+
 	if foundAt == 0 {
-		return false, "", nil // Already at beginning
+		if hasStale {
+			return true, pathActionMove, nil
+		}
+		return false, "", nil // Already at beginning, nothing stale
 	} else if foundAt > 0 {
 		return true, pathActionMove, nil // Exists but not at beginning
 	}
@@ -261,6 +276,7 @@ func modifySystemPath(shimsDir, action string) error {
 	// Parse and filter current PATH entries
 	paths := strings.Split(currentPath, ";")
 	var filteredPaths []string
+	var removedStale []string
 
 	for _, p := range paths {
 		trimmed := strings.TrimSpace(p)
@@ -269,6 +285,11 @@ func modifySystemPath(shimsDir, action string) error {
 		}
 		// Skip if it's the shims dir (we'll prepend it)
 		if strings.EqualFold(trimmed, shimsDir) {
+			continue
+		}
+		// Skip stale dtvem shims entries from prior installs
+		if IsDtvemShimsPath(trimmed) {
+			removedStale = append(removedStale, trimmed)
 			continue
 		}
 		filteredPaths = append(filteredPaths, trimmed)
@@ -288,6 +309,10 @@ func modifySystemPath(shimsDir, action string) error {
 
 	// Broadcast WM_SETTINGCHANGE to notify running processes
 	broadcastSettingChange()
+
+	for _, stale := range removedStale {
+		ui.Success("Removed stale dtvem shims entry from System PATH: %s", stale)
+	}
 
 	if action == pathActionMove {
 		ui.Success("Moved %s to the beginning of your System PATH", shimsDir)
@@ -314,6 +339,7 @@ func modifyUserPath(shimsDir, action string) error {
 
 	// Parse and filter current PATH entries
 	var filteredPaths []string
+	var removedStale []string
 	if currentPath != "" {
 		paths := strings.Split(currentPath, ";")
 		for _, p := range paths {
@@ -323,6 +349,11 @@ func modifyUserPath(shimsDir, action string) error {
 			}
 			// Skip if it's the shims dir (we'll prepend it)
 			if strings.EqualFold(trimmed, shimsDir) {
+				continue
+			}
+			// Skip stale dtvem shims entries from prior installs
+			if IsDtvemShimsPath(trimmed) {
+				removedStale = append(removedStale, trimmed)
 				continue
 			}
 			filteredPaths = append(filteredPaths, trimmed)
@@ -343,6 +374,10 @@ func modifyUserPath(shimsDir, action string) error {
 
 	// Broadcast WM_SETTINGCHANGE to notify running processes
 	broadcastSettingChange()
+
+	for _, stale := range removedStale {
+		ui.Success("Removed stale dtvem shims entry from User PATH: %s", stale)
+	}
 
 	if action == pathActionMove {
 		ui.Success("Moved %s to the beginning of your User PATH", shimsDir)


### PR DESCRIPTION
## Summary

When `XDG_DATA_HOME` is set on Windows/macOS, dtvem honors it for data storage and PATH config. But users who upgraded from a pre-XDG version (or set `XDG_DATA_HOME` after a prior install) end up with a stale `~/.dtvem/shims` entry in PATH pointing at an empty directory, while the real shims live at the XDG-resolved location. `dtvem init` previously only managed the path it currently resolves to and didnt notice the stale leftover.

This PR teaches `dtvem init` to:

- Detect entries in PATH that look like a dtvem shims directory (`*/dtvem/shims` or `*/.dtvem/shims`, case-insensitive on Windows) but dont match the currently-resolved `ShimsDir()`.
- On Windows: remove them from the registry during the existing PATH-modify pass; log each removal in the success output.
- On Unix: warn the user with manual cleanup instructions (we dont auto-rewrite `.bashrc`/`.zshrc` because users often customize them heavily).

## What this fixes

The original bug from #247:

- `XDG_DATA_HOME` set, real shims correctly created at `~/.local/share/dtvem/shims`
- PATH contains stale `~/.dtvem/shims` entry (empty dir) from a prior install
- `dtvem init` previously didnt touch the stale entry

After this PR, running `dtvem init` (then restarting the terminal) on a machine in this state will:

- Remove the stale `~/.dtvem/shims` entry
- Add the correct `~/.local/share/dtvem/shims` entry
- Print which stale entries were removed

## Implementation notes

- New cross-platform helpers in `src/internal/path/path.go`:
  - `IsDtvemShimsPath(path)` — matches both `dtvem/shims` and `.dtvem/shims` parents (case-insensitive on Windows)
  - `FindStaleShimsEntries(entries, currentShimsDir)` — returns entries that look like dtvem shims dirs but arent the current one
  - `SplitPath(pathEnv)` — splits PATH using the OS-appropriate separator
- `path_windows.go`:
  - `checkSystemPath` / `checkUserPath` now flag stale entries as needing an update even when the current `shimsDir` is already at position 0
  - `modifySystemPath` / `modifyUserPath` filter out stale entries during the registry rewrite and log each removal
- `path_unix.go`:
  - `AddToPath` now calls `warnAboutStaleShimsEntries` to surface stale entries with manual cleanup instructions

## Test plan

- [x] `./rnr check` passes (lint + all tests)
- [x] New unit tests cover `IsDtvemShimsPath` (incl. Windows case-insensitivity) and `FindStaleShimsEntries` (incl. `.dtvem` vs `dtvem` parents, ordering preservation, Windows case-insensitive comparison)
- [ ] Manual verification on a setup with both `~/.dtvem/shims` and `~/.local/share/dtvem/shims` in PATH: run `dtvem init`, confirm stale entry is removed and current entry is added
- [ ] Verify Unix warning output matches expectation when a stale entry is in PATH

## Resolves

Resolves #247