### PR TITLE
chore(repo): pin .go files to LF line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.go text eol=lf


### PR DESCRIPTION
## Summary

Add a `.gitattributes` file pinning `*.go` files to LF line endings.

## Why

On Windows with the default `core.autocrlf=true`, Git checks out `.go` files with CRLF, but `gofmt` always writes LF. Result: every `gofmt` run (including `./rnr check`) leaves `.go` files appearing "modified" in `git status`. Staging them re-normalizes to the LF stored in HEAD, so the diff disappears, but the next `gofmt` brings the churn right back.

Pinning `*.go` to `eol=lf` tells Git to keep the working copy as LF on every platform, matching `gofmt`'s output. The cycle stops.

## Notes

- The Go files in this repo are already stored as LF in the object store (running `git add --renormalize .` was a no-op against `.go`), so this is purely a working-copy / checkout-time fix. No file content actually changes.
- Scope kept minimal: only `.go` files. Other file types can be added in follow-ups if they cause similar issues.

## Test plan

- [ ] On a Windows checkout, run `./rnr check` and confirm no `.go` files appear in `git status` afterwards.
- [ ] On macOS/Linux: confirm `git status` still clean after running `./rnr check`.
