### PR TITLE
ci(workflow): drop per-commit message lint, keep PR title check

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,4 +1,4 @@
-name: Lint Commit Messages
+name: Lint PR Title
 
 on:
   pull_request:
@@ -31,29 +31,3 @@ jobs:
         run: |
           echo "Validating PR title: $PR_TITLE"
           echo "$PR_TITLE" | npx commitlint --verbose
-
-  commitlint:
-    name: Lint Commit Messages
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Fetch all history for all branches and tags
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Install commitlint
-        run: |
-          npm install --save-dev @commitlint/cli@18.4.3 @commitlint/config-conventional@18.4.3
-
-      - name: Validate PR commits
-        run: |
-          # Get the base branch (usually main)
-          BASE_SHA=$(git merge-base origin/${{ github.base_ref }} HEAD)
-
-          # Lint all commits in the PR
-          npx commitlint --from $BASE_SHA --to HEAD --verbose


### PR DESCRIPTION
## Summary

- The per-commit `commitlint` job in `.github/workflows/commit-lint.yml` scanned every commit on a PR's branch and blocked merges on header length, even when the PR title (which becomes the squash-merge subject) was already linted separately.
- Removes the `commitlint` job. Keeps the `lint-pr-title` job, which is the source of truth for the conventional-commit format used at merge time.
- Renames the workflow's display name from "Lint Commit Messages" to "Lint PR Title" so it matches what the workflow actually does. Filename is unchanged to avoid disturbing any existing branch-protection references.

## Test plan

- [ ] CI runs on this PR — `Lint PR Title` should pass; the old `Lint Commit Messages` check should no longer appear.